### PR TITLE
feat(ws): add websocket observability telemetry, chaos tests, and configurable harness intervals

### DIFF
--- a/app/jobs/metricsjob/trigger.go
+++ b/app/jobs/metricsjob/trigger.go
@@ -34,6 +34,10 @@ func triggerWithConfig(ctx context.Context, fn func() error, config TriggerConfi
 	}
 }
 
+func TriggerWithConfig(ctx context.Context, fn func() error, config TriggerConfig) {
+	triggerWithConfig(ctx, fn, config)
+}
+
 func Trigger(ctx context.Context, fn func() error) {
 	triggerWithConfig(ctx, fn, DefaultTriggerConfig())
 }

--- a/app/jobs/registrationjob/trigger.go
+++ b/app/jobs/registrationjob/trigger.go
@@ -44,6 +44,10 @@ func triggerWithConfig(fn func() error, config TriggerConfig) {
 	log.Error("Agent registration failed after all retry attempts")
 }
 
+func TriggerWithConfig(fn func() error, config TriggerConfig) {
+	triggerWithConfig(fn, config)
+}
+
 func Trigger(fn func() error) {
 	triggerWithConfig(fn, DefaultTriggerConfig())
 }

--- a/app/jobs/taskjob/result_channel_test.go
+++ b/app/jobs/taskjob/result_channel_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"hostlink/app/services/localtaskstore"
 	"hostlink/app/services/taskreporter"
+	"hostlink/internal/telemetry/telemetrytest"
 	"hostlink/domain/task"
 	"io"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -166,6 +168,24 @@ func TestCaptureStreamRetainsChunkWhenPersistFails(t *testing.T) {
 
 	if channel.outputs[1].Payload != "retry" || channel.outputs[1].Sequence != 1 {
 		t.Fatalf("retry output = %#v", channel.outputs[1])
+	}
+}
+
+func TestTaskJobEnqueueEmitsRunnerQueueDepthTelemetry(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-taskjob-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	job := NewJobWithConf(TaskJobConfig{Trigger: runOnceTrigger})
+
+	if err := job.Enqueue(context.Background(), task.Task{ID: "task-1", ExecutionAttemptID: "attempt-1"}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	entries := telemetrytest.ReadEntries(t, telemetryPath)
+	depth := telemetrytest.FindEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.task_runner.queue.depth" && entry["value"] == float64(1)
+	})
+	if depth["task_id"] != "task-1" || depth["execution_attempt_id"] != "attempt-1" {
+		t.Fatalf("queue depth metric = %#v", depth)
 	}
 }
 

--- a/app/jobs/taskjob/taskjob.go
+++ b/app/jobs/taskjob/taskjob.go
@@ -12,6 +12,7 @@ import (
 	"hostlink/app/services/taskfetcher"
 	"hostlink/app/services/taskreporter"
 	"hostlink/domain/task"
+	"hostlink/internal/telemetry"
 	"io"
 	"os"
 	"os/exec"
@@ -119,6 +120,10 @@ func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr 
 func (tj *TaskJob) Enqueue(ctx context.Context, t task.Task) error {
 	select {
 	case tj.enqueueCh <- t:
+		telemetry.Metric("hostlink.task_runner.queue.depth", len(tj.enqueueCh), map[string]any{
+			"task_id":              t.ID,
+			"execution_attempt_id": t.ExecutionAttemptID,
+		})
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/app/jobs/taskjob/trigger.go
+++ b/app/jobs/taskjob/trigger.go
@@ -34,6 +34,10 @@ func triggerWithConfig(ctx context.Context, fn func() error, config TriggerConfi
 	}
 }
 
+func TriggerWithConfig(ctx context.Context, fn func() error, config TriggerConfig) {
+	triggerWithConfig(ctx, fn, config)
+}
+
 func Trigger(ctx context.Context, fn func() error) {
 	triggerWithConfig(ctx, fn, DefaultTriggerConfig())
 }

--- a/app/services/localtaskstore/outbox_test.go
+++ b/app/services/localtaskstore/outbox_test.go
@@ -1,6 +1,7 @@
 package localtaskstore
 
 import (
+	"hostlink/internal/telemetry/telemetrytest"
 	"path/filepath"
 	"testing"
 
@@ -84,4 +85,43 @@ func TestAckFinalRemovesOutboxButPreservesTaskState(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, state.Exists)
 	require.Equal(t, TaskStatusFinal, state.Status)
+}
+
+func TestOutboxMetricsTrackPendingMessagesBytesAndFinals(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-store-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	store := newTestStore(t, 1024*1024, 1024)
+
+	require.NoError(t, store.AppendOutputChunk(OutputChunk{
+		MessageID:          "msg-output-1",
+		TaskID:             "task-1",
+		ExecutionAttemptID: "attempt-1",
+		Stream:             "stdout",
+		Sequence:           1,
+		Payload:            "hello",
+		ByteCount:          5,
+	}))
+	require.NoError(t, store.RecordFinal(FinalResult{
+		MessageID:          "msg-final-1",
+		TaskID:             "task-1",
+		ExecutionAttemptID: "attempt-1",
+		Status:             "completed",
+		ExitCode:           0,
+		Payload:            `{"status":"completed"}`,
+	}))
+
+	entries := telemetrytest.ReadEntries(t, telemetryPath)
+	pendingMessages := telemetrytest.FindEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.local_store.outbox.pending_messages" && entry["value"] == float64(2)
+	})
+	pendingBytes := telemetrytest.FindEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.local_store.outbox.pending_bytes" && entry["value"] == float64(27)
+	})
+	pendingFinals := telemetrytest.FindEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.local_store.outbox.pending_finals" && entry["value"] == float64(1)
+	})
+	require.Equal(t, "task-1", pendingMessages["task_id"])
+	require.Equal(t, "attempt-1", pendingMessages["execution_attempt_id"])
+	require.Equal(t, "task-1", pendingBytes["task_id"])
+	require.Equal(t, "task-1", pendingFinals["task_id"])
 }

--- a/app/services/localtaskstore/recovery_test.go
+++ b/app/services/localtaskstore/recovery_test.go
@@ -41,6 +41,27 @@ func TestMarkInterruptedRunningTasksQueuesTerminalRecordAcrossRestart(t *testing
 	require.Contains(t, messages[0].Payload, "interrupted")
 }
 
+func TestSnapshotParsesUnackedFinalPayload(t *testing.T) {
+	store := newTestStore(t, 1024*1024, 1024)
+	require.NoError(t, store.RecordFinal(FinalResult{
+		MessageID:          "msg-final-1",
+		TaskID:             "task-1",
+		ExecutionAttemptID: "attempt-1",
+		Status:             "failed",
+		ExitCode:           -1,
+		Payload:            `{"status":"interrupted","exit_code":-1,"output":"partial stdout","error":"interrupted during hostlink restart","output_truncated":true,"error_truncated":false}`,
+	}))
+
+	snapshot, err := store.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.UnackedFinals, 1)
+	require.Equal(t, "interrupted", snapshot.UnackedFinals[0].Status)
+	require.Equal(t, -1, snapshot.UnackedFinals[0].ExitCode)
+	require.Equal(t, "partial stdout", snapshot.UnackedFinals[0].Output)
+	require.Equal(t, "interrupted during hostlink restart", snapshot.UnackedFinals[0].Error)
+	require.True(t, snapshot.UnackedFinals[0].OutputTruncated)
+}
+
 func TestMarkInterruptedRunningTasksIsIdempotent(t *testing.T) {
 	store := newTestStore(t, 1024*1024, 1024)
 

--- a/app/services/localtaskstore/spool_test.go
+++ b/app/services/localtaskstore/spool_test.go
@@ -2,6 +2,8 @@ package localtaskstore
 
 import (
 	"errors"
+	"hostlink/internal/telemetry/telemetrytest"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,6 +58,36 @@ func TestRecordReceivedFailsWhenTerminalReserveUnavailable(t *testing.T) {
 	_, err := store.RecordReceived(TaskReceipt{TaskID: "task-2", ExecutionAttemptID: "attempt-1"})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrTerminalReserveUnavailable))
+}
+
+func TestAppendOutputChunkRotationEmitsTruncationTelemetry(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-store-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	store := newTestStore(t, 16, 4)
+
+	appendChunk(t, store, "msg-1", "task-1", 1, "12345")
+	appendChunk(t, store, "msg-2", "task-1", 2, "67890")
+	appendChunk(t, store, "msg-3", "task-1", 3, "abcde")
+
+	entries := readTelemetryEntries(t, telemetryPath)
+	truncationEvent := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.local_store.output.rotated"
+	})
+	truncationMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.local_store.output.rotated_chunks"
+	})
+	require.Equal(t, "task-1", truncationEvent["task_id"])
+	require.Equal(t, "attempt-1", truncationEvent["execution_attempt_id"])
+	require.Equal(t, "task-1", truncationMetric["task_id"])
+}
+
+func readTelemetryEntries(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	return telemetrytest.ReadEntries(t, path)
+}
+
+func findTelemetryEntry(entries []map[string]any, match func(map[string]any) bool) map[string]any {
+	return telemetrytest.FindEntry(entries, match)
 }
 
 func messageIDs(messages []OutboxMessage) []string {

--- a/app/services/localtaskstore/store.go
+++ b/app/services/localtaskstore/store.go
@@ -1,8 +1,10 @@
 package localtaskstore
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"hostlink/internal/telemetry"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,6 +96,8 @@ type UnackedFinalSnapshot struct {
 	ExecutionAttemptID string
 	Status             string
 	ExitCode           int
+	Output             string
+	Error              string
 	OutputTruncated    bool
 	ErrorTruncated     bool
 }
@@ -140,6 +144,7 @@ type ResultOutbox interface {
 	AppendOutputChunk(OutputChunk) error
 	RecordFinal(FinalResult) error
 	UnackedMessages() ([]OutboxMessage, error)
+	UnackedMessage(messageID string) (OutboxMessage, bool, error)
 	AckMessage(messageID string) error
 	UnackedMessagesFrom(taskID, executionAttemptID, stream string, nextSequence int64) ([]OutboxMessage, error)
 }
@@ -339,7 +344,7 @@ func (s *Store) AppendOutputChunk(chunk OutputChunk) error {
 		return err
 	}
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := s.upsertExecutionState(tx, taskExecutionRecord{
 			TaskID:             chunk.TaskID,
 			ExecutionAttemptID: chunk.ExecutionAttemptID,
@@ -363,6 +368,10 @@ func (s *Store) AppendOutputChunk(chunk OutputChunk) error {
 		}
 		return s.enforceChunkCap(tx)
 	})
+	if err == nil {
+		s.emitOutboxMetrics(chunk.TaskID, chunk.ExecutionAttemptID)
+	}
+	return err
 }
 
 func (s *Store) RecordFinal(result FinalResult) error {
@@ -370,7 +379,7 @@ func (s *Store) RecordFinal(result FinalResult) error {
 		return err
 	}
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := s.rotateChunksForTerminal(tx, int64(len(result.Payload))); err != nil {
 			return err
 		}
@@ -396,6 +405,10 @@ func (s *Store) RecordFinal(result FinalResult) error {
 		}
 		return tx.Create(&record).Error
 	})
+	if err == nil {
+		s.emitOutboxMetrics(result.TaskID, result.ExecutionAttemptID)
+	}
+	return err
 }
 
 func (s *Store) ensureTerminalReserveAvailable(tx *gorm.DB) error {
@@ -469,6 +482,18 @@ func (s *Store) rotateOldestChunk(tx *gorm.DB) (bool, error) {
 	if err := s.markLocalOutputTruncated(tx, oldest.TaskID, oldest.ExecutionAttemptID); err != nil {
 		return false, err
 	}
+	telemetry.Event("hostlink.local_store.output.rotated", map[string]any{
+		"task_id":              oldest.TaskID,
+		"execution_attempt_id": oldest.ExecutionAttemptID,
+		"message_id":           oldest.MessageID,
+		"stream":               oldest.Stream,
+		"sequence":             oldest.Sequence,
+	})
+	telemetry.Metric("hostlink.local_store.output.rotated_chunks", 1, map[string]any{
+		"task_id":              oldest.TaskID,
+		"execution_attempt_id": oldest.ExecutionAttemptID,
+		"message_id":           oldest.MessageID,
+	})
 	return true, nil
 }
 
@@ -510,6 +535,18 @@ func (s *Store) UnackedMessages() ([]OutboxMessage, error) {
 	return messages, nil
 }
 
+func (s *Store) UnackedMessage(messageID string) (OutboxMessage, bool, error) {
+	var record outboxMessageRecord
+	err := s.db.Where("message_id = ? AND acked_at IS NULL", messageID).First(&record).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return OutboxMessage{}, false, nil
+	}
+	if err != nil {
+		return OutboxMessage{}, false, fmt.Errorf("load unacked message: %w", err)
+	}
+	return outboxMessageFromRecord(record), true, nil
+}
+
 func (s *Store) AckMessage(messageID string) error {
 	if messageID == "" {
 		return fmt.Errorf("message ID is required")
@@ -518,6 +555,7 @@ func (s *Store) AckMessage(messageID string) error {
 	if err := s.db.Model(&outboxMessageRecord{}).Where("message_id = ? AND acked_at IS NULL", messageID).Update("acked_at", now).Error; err != nil {
 		return fmt.Errorf("ack message: %w", err)
 	}
+	s.emitOutboxMetrics("", "")
 	return nil
 }
 
@@ -582,12 +620,17 @@ func (s *Store) Snapshot() (Snapshot, error) {
 	for _, msg := range outboxRecords {
 		switch msg.Type {
 		case OutboxMessageTypeFinal:
+			final := finalSnapshotFromOutboxRecord(msg)
 			snapshot.UnackedFinals = append(snapshot.UnackedFinals, UnackedFinalSnapshot{
 				MessageID:          msg.MessageID,
 				TaskID:             msg.TaskID,
 				ExecutionAttemptID: msg.ExecutionAttemptID,
-				Status:             msg.Payload, // simplified; full status parsing not needed for compilation
-				ExitCode:           0,
+				Status:             final.Status,
+				ExitCode:           final.ExitCode,
+				Output:             final.Output,
+				Error:              final.Error,
+				OutputTruncated:    final.OutputTruncated,
+				ErrorTruncated:     final.ErrorTruncated,
 			})
 		case OutboxMessageTypeOutput:
 			snapshot.UnackedOutput = append(snapshot.UnackedOutput, UnackedOutputRange{
@@ -602,6 +645,35 @@ func (s *Store) Snapshot() (Snapshot, error) {
 	}
 
 	return snapshot, nil
+}
+
+type finalSnapshotPayload struct {
+	Status          string `json:"status"`
+	ExitCode        int    `json:"exit_code"`
+	Output          string `json:"output"`
+	Error           string `json:"error"`
+	OutputTruncated bool   `json:"output_truncated"`
+	ErrorTruncated  bool   `json:"error_truncated"`
+}
+
+func finalSnapshotFromOutboxRecord(record outboxMessageRecord) UnackedFinalSnapshot {
+	snapshot := UnackedFinalSnapshot{
+		MessageID:          record.MessageID,
+		TaskID:             record.TaskID,
+		ExecutionAttemptID: record.ExecutionAttemptID,
+	}
+	var payload finalSnapshotPayload
+	if err := json.Unmarshal([]byte(record.Payload), &payload); err != nil {
+		snapshot.Status = record.Payload
+		return snapshot
+	}
+	snapshot.Status = payload.Status
+	snapshot.ExitCode = payload.ExitCode
+	snapshot.Output = payload.Output
+	snapshot.Error = payload.Error
+	snapshot.OutputTruncated = payload.OutputTruncated
+	snapshot.ErrorTruncated = payload.ErrorTruncated
+	return snapshot
 }
 
 func (s *Store) MarkInterruptedRunningTasks() error {
@@ -739,4 +811,29 @@ func outboxMessageFromRecord(record outboxMessageRecord) OutboxMessage {
 
 func interruptedMessageID(taskID, executionAttemptID string) string {
 	return "local-interrupted-" + strings.NewReplacer("/", "-", " ", "-", "|", "-").Replace(taskID+"-"+executionAttemptID)
+}
+
+func (s *Store) emitOutboxMetrics(taskID, executionAttemptID string) {
+	messages, err := s.UnackedMessages()
+	if err != nil {
+		return
+	}
+	var bytesUsed int64
+	var finalsPending int64
+	for _, message := range messages {
+		bytesUsed += message.ByteCount
+		if message.Type == OutboxMessageTypeFinal {
+			finalsPending++
+		}
+	}
+	fields := map[string]any{}
+	if taskID != "" {
+		fields["task_id"] = taskID
+	}
+	if executionAttemptID != "" {
+		fields["execution_attempt_id"] = executionAttemptID
+	}
+	telemetry.Metric("hostlink.local_store.outbox.pending_messages", len(messages), fields)
+	telemetry.Metric("hostlink.local_store.outbox.pending_bytes", bytesUsed, fields)
+	telemetry.Metric("hostlink.local_store.outbox.pending_finals", finalsPending, fields)
 }

--- a/app/services/wsclient/client.go
+++ b/app/services/wsclient/client.go
@@ -6,8 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"hostlink/app/services/localtaskstore"
+	"hostlink/internal/telemetry"
 	"math/rand/v2"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,21 +47,21 @@ type DeliveryCoordinator interface {
 }
 
 type Config struct {
-	URL            string
-	AgentState     *agentstate.AgentState
-	PrivateKeyPath string
-	Dialer         Dialer
-	ReconnectMin   time.Duration
-	ReconnectMax   time.Duration
-	PingInterval   time.Duration
-	SleepFunc      SleepFunc
-	ResultOutbox   localtaskstore.ResultOutbox
-	ReceiptStore   localtaskstore.ReceiptStore
-	RecoveryStore  localtaskstore.RecoveryStore
-	TaskEnqueuer   TaskEnqueuer
-	ResultsEnabled       bool
-	DeliveryEnabled      bool
-	DeliveryCoordinator  DeliveryCoordinator
+	URL                 string
+	AgentState          *agentstate.AgentState
+	PrivateKeyPath      string
+	Dialer              Dialer
+	ReconnectMin        time.Duration
+	ReconnectMax        time.Duration
+	PingInterval        time.Duration
+	SleepFunc           SleepFunc
+	ResultOutbox        localtaskstore.ResultOutbox
+	ReceiptStore        localtaskstore.ReceiptStore
+	RecoveryStore       localtaskstore.RecoveryStore
+	TaskEnqueuer        TaskEnqueuer
+	ResultsEnabled      bool
+	DeliveryEnabled     bool
+	DeliveryCoordinator DeliveryCoordinator
 }
 
 type Client struct {
@@ -70,15 +74,15 @@ type Client struct {
 	pingInterval time.Duration
 	sleep        SleepFunc
 
-	mu       sync.RWMutex
-	writeMu  sync.Mutex
-	active   bool
-	lastAck  *wsprotocol.AckPayload
-	conn     Conn
-	outbox   localtaskstore.ResultOutbox
-	receipts localtaskstore.ReceiptStore
-	recovery localtaskstore.RecoveryStore
-	enqueuer TaskEnqueuer
+	mu                  sync.RWMutex
+	writeMu             sync.Mutex
+	active              bool
+	lastAck             *wsprotocol.AckPayload
+	conn                Conn
+	outbox              localtaskstore.ResultOutbox
+	receipts            localtaskstore.ReceiptStore
+	recovery            localtaskstore.RecoveryStore
+	enqueuer            TaskEnqueuer
 	resultsEnabled      bool
 	deliveryEnabled     bool
 	deliveryCoordinator DeliveryCoordinator
@@ -113,15 +117,15 @@ func New(cfg Config) (*Client, error) {
 	}
 
 	return &Client{
-		url:          cfg.URL,
-		agentID:      agentID,
-		signer:       signer,
-		dialer:       cfg.Dialer,
-		reconnectMin: cfg.ReconnectMin,
-		reconnectMax: cfg.ReconnectMax,
-		pingInterval: cfg.PingInterval,
-		sleep:        cfg.SleepFunc,
-		outbox:       cfg.ResultOutbox,
+		url:                 cfg.URL,
+		agentID:             agentID,
+		signer:              signer,
+		dialer:              cfg.Dialer,
+		reconnectMin:        cfg.ReconnectMin,
+		reconnectMax:        cfg.ReconnectMax,
+		pingInterval:        cfg.PingInterval,
+		sleep:               cfg.SleepFunc,
+		outbox:              cfg.ResultOutbox,
 		receipts:            cfg.ReceiptStore,
 		recovery:            cfg.RecoveryStore,
 		enqueuer:            cfg.TaskEnqueuer,
@@ -133,9 +137,14 @@ func New(cfg Config) (*Client, error) {
 
 func (c *Client) Start(ctx context.Context) error {
 	backoff := c.reconnectMin
+	attempt := 0
 	for {
 		if ctx.Err() != nil {
 			return nil
+		}
+		attempt++
+		if attempt > 1 {
+			telemetry.Metric("hostlink.agent_ws.reconnect.attempts", 1, map[string]any{"agent_id": c.agentID, "attempt": attempt})
 		}
 
 		err := c.runOnce(ctx)
@@ -241,6 +250,13 @@ func (c *Client) readLoop(ctx context.Context, conn Conn, helloMessageID string)
 					return err
 				}
 				c.setActive(true)
+				telemetry.Event("hostlink.agent_ws.session.activated", map[string]any{
+					"agent_id":         c.agentID,
+					"delivery_enabled": c.deliveryEnabled && helloAck.DeliveryEnabled,
+					"acked_message_id": helloAck.AckedMessageID,
+				})
+				telemetry.Metric("hostlink.agent_ws.connections.opened", 1, map[string]any{"agent_id": c.agentID})
+				telemetry.Metric("hostlink.agent_ws.connection.active", 1, map[string]any{"agent_id": c.agentID})
 				if c.deliveryCoordinator != nil {
 					c.deliveryCoordinator.SetSessionDeliveryEnabled(c.deliveryEnabled && helloAck.DeliveryEnabled)
 				}
@@ -262,8 +278,21 @@ func (c *Client) readLoop(ctx context.Context, conn Conn, helloMessageID string)
 				return err
 			}
 			if c.outbox != nil && ack.AckedMessageID != "" {
+				message, found, err := c.outbox.UnackedMessage(ack.AckedMessageID)
+				if err != nil {
+					return err
+				}
 				if err := c.outbox.AckMessage(ack.AckedMessageID); err != nil {
 					return err
+				}
+				if found {
+					telemetry.Event("hostlink.agent_ws.outbox.acknowledged", map[string]any{
+						"agent_id":             c.agentID,
+						"task_id":              message.TaskID,
+						"execution_attempt_id": message.ExecutionAttemptID,
+						"acked_message_id":     ack.AckedMessageID,
+						"acked_type":           string(ack.AckedType),
+					})
 				}
 			}
 			c.setLastAck(&ack)
@@ -273,6 +302,9 @@ func (c *Client) readLoop(ctx context.Context, conn Conn, helloMessageID string)
 				return err
 			}
 			if payload.Retryable {
+				if err := c.handleRetryableError(ctx, conn, payload); err != nil {
+					return err
+				}
 				continue
 			}
 			return fmt.Errorf("websocket protocol error: %s", env.MessageID)
@@ -304,6 +336,9 @@ func (c *Client) receiveTaskDeliver(ctx context.Context, conn Conn, env wsprotoc
 	previous, err := c.receipts.TaskState(env.TaskID, env.ExecutionAttemptID)
 	if err != nil {
 		return err
+	}
+	if previous.Exists {
+		c.emitDuplicateDeliveryTelemetry(env, previous.Status)
 	}
 	state, err := c.receipts.RecordReceived(localtaskstore.TaskReceipt{
 		TaskID:             env.TaskID,
@@ -339,6 +374,20 @@ func (c *Client) receiveTaskDeliver(ctx context.Context, conn Conn, env wsprotoc
 	return nil
 }
 
+func (c *Client) emitDuplicateDeliveryTelemetry(env wsprotocol.Envelope, state string) {
+	telemetry.Event("hostlink.agent_ws.task.deliver.duplicate", map[string]any{
+		"agent_id":             c.agentID,
+		"task_id":              env.TaskID,
+		"execution_attempt_id": env.ExecutionAttemptID,
+		"state":                state,
+	})
+	telemetry.Metric("hostlink.agent_ws.delivery.duplicates", 1, map[string]any{
+		"agent_id":             c.agentID,
+		"task_id":              env.TaskID,
+		"execution_attempt_id": env.ExecutionAttemptID,
+	})
+}
+
 func (c *Client) replayTaskFinal(ctx context.Context, conn Conn, taskID, executionAttemptID string) (bool, error) {
 	if c.outbox == nil {
 		return false, nil
@@ -349,7 +398,7 @@ func (c *Client) replayTaskFinal(ctx context.Context, conn Conn, taskID, executi
 	}
 	for _, message := range messages {
 		if message.TaskID == taskID && message.ExecutionAttemptID == executionAttemptID && message.Type == localtaskstore.OutboxMessageTypeFinal {
-			return true, c.writeEnvelope(ctx, conn, envelopeFromOutboxMessage(c.agentID, message))
+			return true, c.resendOutboxMessage(ctx, conn, message, "duplicate_delivery")
 		}
 	}
 	return false, nil
@@ -365,7 +414,7 @@ func (c *Client) SendOutput(ctx context.Context, chunk localtaskstore.OutputChun
 	if err := c.outbox.AppendOutputChunk(chunk); err != nil {
 		return err
 	}
-	return c.sendIfActive(ctx, envelopeFromOutboxMessage(c.agentID, localtaskstore.OutboxMessage{
+	message := localtaskstore.OutboxMessage{
 		MessageID:          chunk.MessageID,
 		TaskID:             chunk.TaskID,
 		ExecutionAttemptID: chunk.ExecutionAttemptID,
@@ -374,7 +423,24 @@ func (c *Client) SendOutput(ctx context.Context, chunk localtaskstore.OutputChun
 		Sequence:           chunk.Sequence,
 		Payload:            chunk.Payload,
 		ByteCount:          chunk.ByteCount,
-	}))
+	}
+	if shouldDropOutputForChaos(chunk.Sequence) {
+		telemetry.Event("hostlink.agent_ws.chaos.output_dropped", map[string]any{
+			"agent_id":             c.agentID,
+			"task_id":              chunk.TaskID,
+			"execution_attempt_id": chunk.ExecutionAttemptID,
+			"message_id":           chunk.MessageID,
+			"sequence":             chunk.Sequence,
+		})
+		return nil
+	}
+	if err := c.sendIfActive(ctx, envelopeFromOutboxMessage(c.agentID, message)); err != nil {
+		return err
+	}
+	if chaosEnabled("HOSTLINK_WS_CHAOS_DUPLICATE_OUTPUT") {
+		return c.sendIfActive(ctx, envelopeFromOutboxMessage(c.agentID, message))
+	}
+	return nil
 }
 
 func (c *Client) SendFinal(ctx context.Context, result localtaskstore.FinalResult) error {
@@ -400,6 +466,27 @@ func (c *Client) SendFinal(ctx context.Context, result localtaskstore.FinalResul
 	}
 	if !c.IsActive() {
 		return fmt.Errorf("websocket result channel is inactive")
+	}
+	return nil
+}
+
+func (c *Client) handleRetryableError(ctx context.Context, conn Conn, payload wsprotocol.ErrorPayload) error {
+	if c.outbox == nil || payload.Code != "output_sequence_gap" || payload.RelatedMessageID == "" || payload.HighestAcceptedSequence == nil {
+		return nil
+	}
+	message, found, err := c.outbox.UnackedMessage(payload.RelatedMessageID)
+	if err != nil || !found {
+		return err
+	}
+	nextSequence := int64(*payload.HighestAcceptedSequence + 1)
+	messages, err := c.outbox.UnackedMessagesFrom(message.TaskID, message.ExecutionAttemptID, message.Stream, nextSequence)
+	if err != nil {
+		return err
+	}
+	for _, replay := range messages {
+		if err := c.resendOutboxMessage(ctx, conn, replay, "retryable_output_gap"); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -480,6 +567,8 @@ func (c *Client) buildHelloPayload() wsprotocol.HelloPayload {
 			ExecutionAttemptID: final.ExecutionAttemptID,
 			Status:             wsprotocol.FinalStatus(final.Status),
 			ExitCode:           final.ExitCode,
+			Output:             final.Output,
+			Error:              final.Error,
 			OutputTruncated:    final.OutputTruncated,
 			ErrorTruncated:     final.ErrorTruncated,
 		})
@@ -505,8 +594,21 @@ func (c *Client) buildHelloPayload() wsprotocol.HelloPayload {
 func (c *Client) applyHelloAckLocalState(ack wsprotocol.HelloAckPayload) error {
 	if c.outbox != nil {
 		for _, messageID := range ack.AcknowledgedFinalMessageIDs {
+			message, found, err := c.outbox.UnackedMessage(messageID)
+			if err != nil {
+				return err
+			}
 			if err := c.outbox.AckMessage(messageID); err != nil {
 				return err
+			}
+			if found {
+				telemetry.Event("hostlink.agent_ws.outbox.acknowledged", map[string]any{
+					"agent_id":             c.agentID,
+					"task_id":              message.TaskID,
+					"execution_attempt_id": message.ExecutionAttemptID,
+					"acked_message_id":     messageID,
+					"acked_type":           string(protocolMessageTypeForOutboxMessage(message)),
+				})
 			}
 		}
 	}
@@ -530,7 +632,7 @@ func (c *Client) replayRequestedOutput(ctx context.Context, conn Conn, replayReq
 			return err
 		}
 		for _, message := range messages {
-			if err := c.writeEnvelope(ctx, conn, envelopeFromOutboxMessage(c.agentID, message)); err != nil {
+			if err := c.resendOutboxMessage(ctx, conn, message, "output_replay"); err != nil {
 				return err
 			}
 		}
@@ -558,6 +660,11 @@ func (c *Client) setActive(active bool) {
 	c.active = active
 	if wasActive && !active && c.deliveryCoordinator != nil {
 		c.deliveryCoordinator.MarkSessionInactive()
+	}
+	if wasActive && !active {
+		telemetry.Event("hostlink.agent_ws.session.disconnected", map[string]any{"agent_id": c.agentID})
+		telemetry.Metric("hostlink.agent_ws.connections.closed", 1, map[string]any{"agent_id": c.agentID})
+		telemetry.Metric("hostlink.agent_ws.connection.active", 0, map[string]any{"agent_id": c.agentID})
 	}
 }
 
@@ -610,11 +717,23 @@ func (c *Client) replayUnacked(ctx context.Context, conn Conn) error {
 		return err
 	}
 	for _, message := range messages {
-		if err := c.writeEnvelope(ctx, conn, envelopeFromOutboxMessage(c.agentID, message)); err != nil {
+		if err := c.resendOutboxMessage(ctx, conn, message, "hello_replay"); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (c *Client) resendOutboxMessage(ctx context.Context, conn Conn, message localtaskstore.OutboxMessage, reason string) error {
+	telemetry.Metric("hostlink.agent_ws.outbox.resends", 1, map[string]any{
+		"agent_id":             c.agentID,
+		"task_id":              message.TaskID,
+		"execution_attempt_id": message.ExecutionAttemptID,
+		"message_id":           message.MessageID,
+		"message_type":         string(protocolMessageTypeForOutboxMessage(message)),
+		"reason":               reason,
+	})
+	return c.writeEnvelope(ctx, conn, envelopeFromOutboxMessage(c.agentID, message))
 }
 
 func (c *Client) writeEnvelope(ctx context.Context, conn Conn, env wsprotocol.Envelope) error {
@@ -666,6 +785,14 @@ func envelopeFromOutboxMessage(agentID string, message localtaskstore.OutboxMess
 	}
 }
 
+func protocolMessageTypeForOutboxMessage(message localtaskstore.OutboxMessage) wsprotocol.MessageType {
+	if message.Type == localtaskstore.OutboxMessageTypeOutput {
+		return wsprotocol.TypeTaskOutput
+	}
+
+	return wsprotocol.TypeTaskFinal
+}
+
 func sleepContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
@@ -675,6 +802,19 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func chaosEnabled(name string) bool {
+	return strings.EqualFold(os.Getenv(name), "true") || os.Getenv(name) == "1"
+}
+
+func shouldDropOutputForChaos(sequence int64) bool {
+	raw := strings.TrimSpace(os.Getenv("HOSTLINK_WS_CHAOS_DROP_OUTPUT_SEQUENCE"))
+	if raw == "" {
+		return false
+	}
+	dropSequence, err := strconv.ParseInt(raw, 10, 64)
+	return err == nil && dropSequence == sequence
 }
 
 func jitter(d time.Duration) time.Duration {

--- a/app/services/wsclient/client_test.go
+++ b/app/services/wsclient/client_test.go
@@ -11,6 +11,7 @@ import (
 	"hostlink/app/services/localtaskstore"
 	"hostlink/app/services/rollout"
 	"hostlink/domain/task"
+	"hostlink/internal/telemetry/telemetrytest"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -111,6 +112,97 @@ func TestClientHelloAckUpdatesPollingCoordinator(t *testing.T) {
 	now = now.Add(6 * time.Second)
 	if !coordinator.ShouldPoll() {
 		t.Fatal("polling did not resume after fallback threshold elapsed")
+	}
+}
+
+func TestClientReconnectAttemptEmitsTelemetry(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	first := newFakeConn()
+	second := newFakeConn()
+	dialer := &fakeDialer{conns: []*fakeConn{first, second}}
+	sleeps := make(chan time.Duration, 2)
+	client := newTestClient(t, dialer, WithSleepFunc(func(ctx context.Context, d time.Duration) error {
+		sleeps <- d
+		return nil
+	}))
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	first.waitForWrite(t)
+	first.readErr <- errors.New("server closed")
+	select {
+	case <-sleeps:
+	case <-time.After(time.Second):
+		t.Fatal("expected reconnect backoff sleep")
+	}
+	second.waitForWrite(t)
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	entries := telemetryEntries(t, telemetryPath)
+	reconnectMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.reconnect.attempts"
+	})
+	if reconnectMetric["agent_id"] != "agent_ws_test" {
+		t.Fatalf("reconnect metric = %#v", reconnectMetric)
+	}
+}
+
+func TestClientSessionLifecycleEmitsTelemetry(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	conn := newFakeConn()
+	dialer := &fakeDialer{conn: conn}
+	client := newTestClient(t, dialer)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	hello := conn.waitForWrite(t)
+	conn.readCh <- helloAckEnvelope(hello.MessageID)
+	waitFor(t, func() bool { return client.IsActive() }, "client to become active")
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	entries := telemetryEntries(t, telemetryPath)
+	activated := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.session.activated"
+	})
+	opened := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.connections.opened"
+	})
+	connected := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.connection.active" && entry["value"] == float64(1)
+	})
+	disconnected := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.session.disconnected"
+	})
+	closed := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.connections.closed"
+	})
+
+	if activated["agent_id"] != "agent_ws_test" {
+		t.Fatalf("activated entry = %#v", activated)
+	}
+	if opened["agent_id"] != "agent_ws_test" {
+		t.Fatalf("opened metric = %#v", opened)
+	}
+	if connected["agent_id"] != "agent_ws_test" {
+		t.Fatalf("connected metric = %#v", connected)
+	}
+	if disconnected["agent_id"] != "agent_ws_test" {
+		t.Fatalf("disconnected entry = %#v", disconnected)
+	}
+	if closed["agent_id"] != "agent_ws_test" {
+		t.Fatalf("closed metric = %#v", closed)
 	}
 }
 
@@ -297,6 +389,8 @@ func TestClientDeliveryOnlySendsStartedButFallsBackToHTTPFinal(t *testing.T) {
 }
 
 func TestClientDuplicateTaskDeliverReacksWithoutDuplicateQueue(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
 	store := newClientTestStore(t)
 	requireNoError(t, store.RecordStarted("task-1", "attempt-1"))
 	enqueuer := &fakeTaskEnqueuer{}
@@ -320,6 +414,19 @@ func TestClientDuplicateTaskDeliverReacksWithoutDuplicateQueue(t *testing.T) {
 	if len(enqueuer.tasks()) != 0 {
 		t.Fatalf("queued tasks = %#v, want none", enqueuer.tasks())
 	}
+	entries := telemetryEntries(t, telemetryPath)
+	duplicate := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.task.deliver.duplicate"
+	})
+	duplicateMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.delivery.duplicates"
+	})
+	if duplicate["task_id"] != "task-1" || duplicate["execution_attempt_id"] != "attempt-1" {
+		t.Fatalf("duplicate entry = %#v", duplicate)
+	}
+	if duplicateMetric["task_id"] != "task-1" {
+		t.Fatalf("duplicate metric = %#v", duplicateMetric)
+	}
 	cancel()
 	if err := <-done; err != nil {
 		t.Fatalf("Start returned error: %v", err)
@@ -327,6 +434,8 @@ func TestClientDuplicateTaskDeliverReacksWithoutDuplicateQueue(t *testing.T) {
 }
 
 func TestClientReceivedDuplicateTaskDeliverReacksWithoutDuplicateQueue(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
 	store := newClientTestStore(t)
 	_, err := store.RecordReceived(localtaskstore.TaskReceipt{TaskID: "task-1", ExecutionAttemptID: "attempt-1"})
 	requireNoError(t, err)
@@ -350,6 +459,19 @@ func TestClientReceivedDuplicateTaskDeliverReacksWithoutDuplicateQueue(t *testin
 	}
 	if len(enqueuer.tasks()) != 0 {
 		t.Fatalf("queued tasks = %#v, want none", enqueuer.tasks())
+	}
+	entries := telemetryEntries(t, telemetryPath)
+	duplicate := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.task.deliver.duplicate"
+	})
+	duplicateMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.delivery.duplicates"
+	})
+	if duplicate["state"] != localtaskstore.TaskStatusReceived {
+		t.Fatalf("duplicate entry = %#v", duplicate)
+	}
+	if duplicateMetric["task_id"] != "task-1" {
+		t.Fatalf("duplicate metric = %#v", duplicateMetric)
 	}
 	cancel()
 	if err := <-done; err != nil {
@@ -398,7 +520,52 @@ func TestClientFinalDuplicateTaskDeliverResendsUnackedFinalWithoutQueue(t *testi
 	}
 }
 
+func TestClientHelloAckAcknowledgedFinalsEmitOutboxAcknowledgementTelemetry(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
+	store := newClientTestStore(t)
+	requireNoError(t, store.RecordFinal(localtaskstore.FinalResult{
+		MessageID:          "msg-final-1",
+		TaskID:             "task-1",
+		ExecutionAttemptID: "attempt-1",
+		Status:             "completed",
+		ExitCode:           0,
+		Payload:            `{"status":"completed","exit_code":0,"output_truncated":false,"error_truncated":false}`,
+	}))
+	conn := newFakeConn()
+	dialer := &fakeDialer{conn: conn}
+	client := newTestClient(t, dialer, WithResultOutbox(store))
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	hello := conn.waitForWrite(t)
+	conn.readCh <- helloAckEnvelopeWithDirectives(hello.MessageID, wsprotocol.HelloAckPayload{
+		AcknowledgedFinalMessageIDs: []string{"msg-final-1"},
+	})
+
+	waitFor(t, func() bool {
+		messages, err := store.UnackedMessages()
+		return err == nil && len(messages) == 0
+	}, "hello ack to remove final outbox message")
+	entries := telemetryEntries(t, telemetryPath)
+	acknowledged := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.outbox.acknowledged" && entry["acked_message_id"] == "msg-final-1"
+	})
+	if acknowledged["acked_type"] != string(wsprotocol.TypeTaskFinal) || acknowledged["task_id"] != "task-1" {
+		t.Fatalf("acknowledged event = %#v", acknowledged)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+}
+
 func TestClientAckRemovesResultMessageFromOutbox(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
 	store := newClientTestStore(t)
 	requireNoError(t, store.AppendOutputChunk(localtaskstore.OutputChunk{
 		MessageID:          "msg-output-1",
@@ -425,6 +592,19 @@ func TestClientAckRemovesResultMessageFromOutbox(t *testing.T) {
 		messages, err := store.UnackedMessages()
 		return err == nil && len(messages) == 0
 	}, "ack to remove outbox message")
+	entries := telemetryEntries(t, telemetryPath)
+	ackMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.local_store.outbox.pending_messages" && entry["value"] == float64(0)
+	})
+	finalPendingAck := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["event"] == "hostlink.agent_ws.outbox.acknowledged" && entry["acked_message_id"] == "msg-output-1"
+	})
+	if ackMetric["metric_name"] != "hostlink.local_store.outbox.pending_messages" {
+		t.Fatalf("ack metric = %#v", ackMetric)
+	}
+	if finalPendingAck["task_id"] != "task-1" || finalPendingAck["execution_attempt_id"] != "attempt-1" {
+		t.Fatalf("ack event = %#v", finalPendingAck)
+	}
 	cancel()
 	if err := <-done; err != nil {
 		t.Fatalf("Start returned error: %v", err)
@@ -432,6 +612,8 @@ func TestClientAckRemovesResultMessageFromOutbox(t *testing.T) {
 }
 
 func TestClientReplaysUnackedMessagesAfterHelloAck(t *testing.T) {
+	telemetryPath := filepath.Join(t.TempDir(), "hostlink-ws-telemetry.jsonl")
+	t.Setenv("HOSTLINK_WS_TELEMETRY_PATH", telemetryPath)
 	store := newClientTestStore(t)
 	requireNoError(t, store.AppendOutputChunk(localtaskstore.OutputChunk{
 		MessageID:          "msg-output-1",
@@ -479,6 +661,19 @@ func TestClientReplaysUnackedMessagesAfterHelloAck(t *testing.T) {
 	}
 	if final.MessageID != "msg-final-1" || final.Type != wsprotocol.TypeTaskFinal {
 		t.Fatalf("second replay = %#v", final)
+	}
+	entries := telemetryEntries(t, telemetryPath)
+	outputResend := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.outbox.resends" && entry["message_id"] == "msg-output-1"
+	})
+	finalResend := findTelemetryEntry(entries, func(entry map[string]any) bool {
+		return entry["metric_name"] == "hostlink.agent_ws.outbox.resends" && entry["message_id"] == "msg-final-1"
+	})
+	if outputResend["message_type"] != string(wsprotocol.TypeTaskOutput) {
+		t.Fatalf("output resend = %#v", outputResend)
+	}
+	if finalResend["message_type"] != string(wsprotocol.TypeTaskFinal) {
+		t.Fatalf("final resend = %#v", finalResend)
 	}
 	cancel()
 	if err := <-done; err != nil {
@@ -529,6 +724,121 @@ func TestClientRetryableErrorKeepsConnectionAndOutboxMessage(t *testing.T) {
 	}
 	if len(messages) != 1 || messages[0].MessageID != "msg-output-1" {
 		t.Fatalf("messages = %#v", messages)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+}
+
+func TestClientRetryableOutputGapReplaysFromHighestAcceptedSequence(t *testing.T) {
+	store := newClientTestStore(t)
+	conn := newFakeConn()
+	dialer := &fakeDialer{conn: conn}
+	client := newTestClient(t, dialer, WithResultOutbox(store))
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	hello := conn.waitForWrite(t)
+	conn.readCh <- helloAckEnvelopeWithDirectives(hello.MessageID, wsprotocol.HelloAckPayload{OutputReplay: []wsprotocol.OutputReplayDirective{}})
+	waitFor(t, func() bool { return client.IsActive() }, "client to become active")
+	requireNoError(t, client.SendOutput(context.Background(), localtaskstore.OutputChunk{
+		MessageID: "msg-output-1", TaskID: "task-1", ExecutionAttemptID: "attempt-1", Stream: "stdout", Sequence: 1, Payload: "hello", ByteCount: 5,
+	}))
+	requireNoError(t, client.SendOutput(context.Background(), localtaskstore.OutputChunk{
+		MessageID: "msg-output-2", TaskID: "task-1", ExecutionAttemptID: "attempt-1", Stream: "stdout", Sequence: 2, Payload: "world", ByteCount: 5,
+	}))
+	_ = conn.waitForWrite(t)
+	_ = conn.waitForWrite(t)
+
+	zero := 0
+	conn.readCh <- wsprotocol.Envelope{
+		ProtocolVersion: wsprotocol.ProtocolVersion,
+		MessageID:       "msg_error",
+		Type:            wsprotocol.TypeError,
+		AgentID:         "agent_ws_test",
+		SentAt:          time.Now().UTC().Format(time.RFC3339),
+		Payload: payloadMap(t, wsprotocol.BuildError(wsprotocol.ErrorOptions{
+			Code:                    "output_sequence_gap",
+			Message:                 "expected sequence 1",
+			Retryable:               true,
+			RelatedMessageID:        "msg-output-2",
+			HighestAcceptedSequence: &zero,
+		})),
+	}
+
+	replayedFirst := conn.waitForWrite(t)
+	replayedSecond := conn.waitForWrite(t)
+	if replayedFirst.MessageID != "msg-output-1" || replayedSecond.MessageID != "msg-output-2" {
+		t.Fatalf("replayed messages = %#v then %#v", replayedFirst, replayedSecond)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+}
+
+func TestClientDuplicateOutputChaosSendsChunkTwice(t *testing.T) {
+	t.Setenv("HOSTLINK_WS_CHAOS_DUPLICATE_OUTPUT", "true")
+	store := newClientTestStore(t)
+	conn := newFakeConn()
+	dialer := &fakeDialer{conn: conn}
+	client := newTestClient(t, dialer, WithResultOutbox(store))
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	hello := conn.waitForWrite(t)
+	conn.readCh <- helloAckEnvelopeWithDirectives(hello.MessageID, wsprotocol.HelloAckPayload{OutputReplay: []wsprotocol.OutputReplayDirective{}})
+	waitFor(t, func() bool { return client.IsActive() }, "client to become active")
+	requireNoError(t, client.SendOutput(context.Background(), localtaskstore.OutputChunk{
+		MessageID: "msg-output-1", TaskID: "task-1", ExecutionAttemptID: "attempt-1", Stream: "stdout", Sequence: 1, Payload: "hello", ByteCount: 5,
+	}))
+
+	first := conn.waitForWrite(t)
+	duplicate := conn.waitForWrite(t)
+	if first.MessageID != "msg-output-1" || duplicate.MessageID != "msg-output-1" {
+		t.Fatalf("duplicate output writes = %#v then %#v", first, duplicate)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+}
+
+func TestClientDropOutputSequenceChaosStoresButDoesNotSendOnce(t *testing.T) {
+	t.Setenv("HOSTLINK_WS_CHAOS_DROP_OUTPUT_SEQUENCE", "1")
+	store := newClientTestStore(t)
+	conn := newFakeConn()
+	dialer := &fakeDialer{conn: conn}
+	client := newTestClient(t, dialer, WithResultOutbox(store))
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- client.Start(runCtx) }()
+
+	hello := conn.waitForWrite(t)
+	conn.readCh <- helloAckEnvelopeWithDirectives(hello.MessageID, wsprotocol.HelloAckPayload{OutputReplay: []wsprotocol.OutputReplayDirective{}})
+	waitFor(t, func() bool { return client.IsActive() }, "client to become active")
+	requireNoError(t, client.SendOutput(context.Background(), localtaskstore.OutputChunk{
+		MessageID: "msg-output-1", TaskID: "task-1", ExecutionAttemptID: "attempt-1", Stream: "stdout", Sequence: 1, Payload: "hello", ByteCount: 5,
+	}))
+
+	select {
+	case written := <-conn.writeCh:
+		t.Fatalf("unexpected output write = %#v", written)
+	case <-time.After(20 * time.Millisecond):
+	}
+	messages, err := store.UnackedMessages()
+	requireNoError(t, err)
+	if len(messages) != 1 || messages[0].MessageID != "msg-output-1" {
+		t.Fatalf("stored messages = %#v", messages)
 	}
 	cancel()
 	if err := <-done; err != nil {
@@ -669,14 +979,14 @@ func newTestClient(t *testing.T, dialer Dialer, opts ...clientOption) *Client {
 		t.Fatalf("set agent ID: %v", err)
 	}
 	cfg := Config{
-		URL:            "ws://example.test/api/v1/agents/ws",
-		AgentState:     state,
-		PrivateKeyPath: saveTestPrivateKey(t, t.TempDir()),
-		Dialer:         dialer,
-		ReconnectMin:   time.Millisecond,
-		ReconnectMax:   10 * time.Millisecond,
-		PingInterval:   time.Hour,
-		ResultsEnabled: true,
+		URL:             "ws://example.test/api/v1/agents/ws",
+		AgentState:      state,
+		PrivateKeyPath:  saveTestPrivateKey(t, t.TempDir()),
+		Dialer:          dialer,
+		ReconnectMin:    time.Millisecond,
+		ReconnectMax:    10 * time.Millisecond,
+		PingInterval:    time.Hour,
+		ResultsEnabled:  true,
 		DeliveryEnabled: true,
 	}
 	for _, opt := range opts {
@@ -940,6 +1250,15 @@ func requireNoError(t *testing.T, err error) {
 
 func intValuePtr(value int) *int {
 	return &value
+}
+
+func telemetryEntries(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	return telemetrytest.ReadEntries(t, path)
+}
+
+func findTelemetryEntry(entries []map[string]any, match func(map[string]any) bool) map[string]any {
+	return telemetrytest.FindEntry(entries, match)
 }
 
 func saveTestPrivateKey(t *testing.T, dir string) string {

--- a/config/appconf/appconf.go
+++ b/config/appconf/appconf.go
@@ -164,6 +164,42 @@ func WebSocketPingInterval() time.Duration {
 	return parseDurationClamped("HOSTLINK_WS_PING_INTERVAL", 30*time.Second, 5*time.Second, 5*time.Minute)
 }
 
+// RegistrationRetryInitialDelay returns the first retry delay for agent registration.
+// Controlled by HOSTLINK_REGISTRATION_RETRY_INITIAL_DELAY (default: 10s, clamped to [10ms, 5m]).
+func RegistrationRetryInitialDelay() time.Duration {
+	return parseDurationClamped("HOSTLINK_REGISTRATION_RETRY_INITIAL_DELAY", 10*time.Second, 10*time.Millisecond, 5*time.Minute)
+}
+
+// TaskPollInterval returns the interval between task polling attempts.
+// Controlled by HOSTLINK_TASK_POLL_INTERVAL (default: 10s, clamped to [10ms, 5m]).
+func TaskPollInterval() time.Duration {
+	return parseDurationClamped("HOSTLINK_TASK_POLL_INTERVAL", 10*time.Second, 10*time.Millisecond, 5*time.Minute)
+}
+
+// TaskOutputFlushInterval returns how often buffered task output is flushed.
+// Controlled by HOSTLINK_TASK_OUTPUT_FLUSH_INTERVAL (default: 100ms, clamped to [1ms, 5s]).
+func TaskOutputFlushInterval() time.Duration {
+	return parseDurationClamped("HOSTLINK_TASK_OUTPUT_FLUSH_INTERVAL", 100*time.Millisecond, time.Millisecond, 5*time.Second)
+}
+
+// TaskOutputFlushThreshold returns the buffered task output byte threshold.
+// Controlled by HOSTLINK_TASK_OUTPUT_FLUSH_THRESHOLD (default: 16KiB).
+func TaskOutputFlushThreshold() int {
+	return int(parseInt64Positive("HOSTLINK_TASK_OUTPUT_FLUSH_THRESHOLD", 16*1024))
+}
+
+// MetricsPushInterval returns the interval between metrics push attempts.
+// Controlled by HOSTLINK_METRICS_PUSH_INTERVAL (default: 20s, clamped to [10ms, 5m]).
+func MetricsPushInterval() time.Duration {
+	return parseDurationClamped("HOSTLINK_METRICS_PUSH_INTERVAL", 20*time.Second, 10*time.Millisecond, 5*time.Minute)
+}
+
+// HeartbeatInterval returns the interval between heartbeat attempts.
+// Controlled by HOSTLINK_HEARTBEAT_INTERVAL (default: 5s, clamped to [10ms, 5m]).
+func HeartbeatInterval() time.Duration {
+	return parseDurationClamped("HOSTLINK_HEARTBEAT_INTERVAL", 5*time.Second, 10*time.Millisecond, 5*time.Minute)
+}
+
 // UpdateCheckInterval returns the interval between update checks.
 // Controlled by HOSTLINK_UPDATE_CHECK_INTERVAL (default: 5m, clamped to [1m, 24h]).
 func UpdateCheckInterval() time.Duration {

--- a/config/appconf/appconf_test.go
+++ b/config/appconf/appconf_test.go
@@ -178,6 +178,34 @@ func TestWebSocketPingInterval_CustomValue(t *testing.T) {
 	assert.Equal(t, 45*time.Second, WebSocketPingInterval())
 }
 
+func TestRegistrationRetryInitialDelay_CustomValue(t *testing.T) {
+	t.Setenv("HOSTLINK_REGISTRATION_RETRY_INITIAL_DELAY", "50ms")
+	assert.Equal(t, 50*time.Millisecond, RegistrationRetryInitialDelay())
+}
+
+func TestTaskPollInterval_CustomValue(t *testing.T) {
+	t.Setenv("HOSTLINK_TASK_POLL_INTERVAL", "100ms")
+	assert.Equal(t, 100*time.Millisecond, TaskPollInterval())
+}
+
+func TestTaskOutputFlushConfig_CustomValues(t *testing.T) {
+	t.Setenv("HOSTLINK_TASK_OUTPUT_FLUSH_INTERVAL", "25ms")
+	t.Setenv("HOSTLINK_TASK_OUTPUT_FLUSH_THRESHOLD", "512")
+
+	assert.Equal(t, 25*time.Millisecond, TaskOutputFlushInterval())
+	assert.Equal(t, 512, TaskOutputFlushThreshold())
+}
+
+func TestMetricsPushInterval_CustomValue(t *testing.T) {
+	t.Setenv("HOSTLINK_METRICS_PUSH_INTERVAL", "250ms")
+	assert.Equal(t, 250*time.Millisecond, MetricsPushInterval())
+}
+
+func TestHeartbeatInterval_CustomValue(t *testing.T) {
+	t.Setenv("HOSTLINK_HEARTBEAT_INTERVAL", "200ms")
+	assert.Equal(t, 200*time.Millisecond, HeartbeatInterval())
+}
+
 func TestLocalTaskStorePath_DefaultUnderAgentStatePath(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("HOSTLINK_STATE_PATH", stateDir)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,53 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+var mu sync.Mutex
+
+func Event(name string, fields map[string]any) {
+	write(merge(fields, map[string]any{"event": name}))
+}
+
+func Metric(name string, value any, fields map[string]any) {
+	write(merge(fields, map[string]any{"metric_name": name, "value": value}))
+}
+
+func write(entry map[string]any) {
+	path := os.Getenv("HOSTLINK_WS_TELEMETRY_PATH")
+	if path == "" {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	entry["recorded_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_, _ = file.Write(append(data, '\n'))
+}
+
+func merge(fields map[string]any, base map[string]any) map[string]any {
+	merged := map[string]any{}
+	for key, value := range fields {
+		merged[key] = value
+	}
+	for key, value := range base {
+		merged[key] = value
+	}
+	return merged
+}

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -1,0 +1,52 @@
+package telemetrytest
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func ReadEntries(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read telemetry file: %v", err)
+	}
+	lines := splitNonEmptyLines(data)
+	entries := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal telemetry line %q: %v", string(line), err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func FindEntry(entries []map[string]any, match func(map[string]any) bool) map[string]any {
+	for _, entry := range entries {
+		if match(entry) {
+			return entry
+		}
+	}
+	return map[string]any{}
+}
+
+func splitNonEmptyLines(data []byte) [][]byte {
+	lines := [][]byte{}
+	start := 0
+	for i, b := range data {
+		if b != '\n' {
+			continue
+		}
+		if i > start {
+			lines = append(lines, data[start:i])
+		}
+		start = i + 1
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}

--- a/internal/wsprotocol/message.go
+++ b/internal/wsprotocol/message.go
@@ -71,6 +71,8 @@ type UnackedFinalSnapshot struct {
 	ExecutionAttemptID string      `json:"execution_attempt_id"`
 	Status             FinalStatus `json:"status"`
 	ExitCode           int         `json:"exit_code"`
+	Output             string      `json:"output,omitempty"`
+	Error              string      `json:"error,omitempty"`
 	OutputTruncated    bool        `json:"output_truncated"`
 	ErrorTruncated     bool        `json:"error_truncated"`
 }

--- a/main.go
+++ b/main.go
@@ -252,7 +252,8 @@ func runServer(ctx context.Context, cmd *cli.Command) error {
 
 	// Agent-related jobs run in goroutine after registration
 	go func() {
-		ctx := context.Background()
+		jobCtx, cancelJobs := context.WithCancel(ctx)
+		defer cancelJobs()
 		localStore, err := recoverLocalTaskStore()
 		if err != nil {
 			log.Printf("failed to initialize local task store: %v", err)
@@ -262,7 +263,17 @@ func runServer(ctx context.Context, cmd *cli.Command) error {
 
 		registeredChan := make(chan bool, 1)
 
-		registrationJob := registrationjob.New()
+		registrationJob := registrationjob.NewWithConfig(&registrationjob.Config{
+			FingerprintPath: appconf.AgentFingerprintPath(),
+			AgentState:      agentstate.New(appconf.AgentStatePath()),
+			Trigger: func(fn func() error) {
+				registrationjob.TriggerWithConfig(fn, registrationjob.TriggerConfig{
+					MaxRetries:    5,
+					InitialDelay:  appconf.RegistrationRetryInitialDelay(),
+					BackoffFactor: 2,
+				})
+			},
+		})
 		registrationJob.Register(registeredChan)
 
 		// Wait for registration to complete
@@ -270,8 +281,15 @@ func runServer(ctx context.Context, cmd *cli.Command) error {
 		log.Println("Agent registered, starting task job...")
 		deliveryCoordinator := rollout.NewCoordinator(appconf.WebSocketDeliveryEnabled(), appconf.WebSocketPollingFallbackThreshold())
 		var resultChannel taskjob.ResultChannel
-		taskJob := taskjob.NewJobWithConf(taskjob.TaskJobConfig{PollingGate: deliveryCoordinator})
-		startWebSocketClientIfEnabled(ctx, func() (webSocketRuntime, error) {
+		taskJob := taskjob.NewJobWithConf(taskjob.TaskJobConfig{
+			PollingGate:          deliveryCoordinator,
+			OutputFlushInterval:  appconf.TaskOutputFlushInterval(),
+			OutputFlushThreshold: appconf.TaskOutputFlushThreshold(),
+			Trigger: func(ctx context.Context, fn func() error) {
+				taskjob.TriggerWithConfig(ctx, fn, taskjob.TriggerConfig{InitialDelay: appconf.TaskPollInterval()})
+			},
+		})
+		startWebSocketClientIfEnabled(jobCtx, func() (webSocketRuntime, error) {
 			runtime, err := newDefaultWebSocketRuntime(localStore, taskJob, deliveryCoordinator)
 			if err == nil {
 				resultChannel = runtime.(taskjob.ResultChannel)
@@ -289,28 +307,39 @@ func runServer(ctx context.Context, cmd *cli.Command) error {
 			log.Printf("failed to initialize task reporter: %v", err)
 			return
 		}
-		taskJob.Register(ctx, fetcher, reporter, resultChannel)
+		taskJob.Register(jobCtx, fetcher, reporter, resultChannel)
 
 		metricsReporter, err := metrics.New()
 		if err != nil {
 			log.Printf("failed to initialize metrics reporter: %v", err)
 			return
 		}
-		metricsJob := metricsjob.New()
-		metricsJob.Register(ctx, metricsReporter, metricsReporter)
+		metricsJob := metricsjob.NewJobWithConf(metricsjob.MetricsJobConfig{
+			Trigger: func(ctx context.Context, fn func() error) {
+				metricsjob.TriggerWithConfig(ctx, fn, metricsjob.TriggerConfig{InitialDelay: appconf.MetricsPushInterval()})
+			},
+			CredFetchInterval: 2,
+		})
+		metricsJob.Register(jobCtx, metricsReporter, metricsReporter)
 
 		heartbeatSvc, err := heartbeat.New()
 		if err != nil {
 			log.Printf("failed to initialize heartbeat service: %v", err)
 			return
 		}
-		heartbeatJob := heartbeatjob.New()
-		heartbeatJob.Register(ctx, heartbeatSvc)
+		heartbeatJob := heartbeatjob.NewWithConfig(heartbeatjob.HeartbeatJobConfig{
+			Trigger: func(ctx context.Context, fn func() error) {
+				heartbeatjob.TriggerWithConfig(ctx, fn, heartbeatjob.TriggerConfig{Interval: appconf.HeartbeatInterval()})
+			},
+		})
+		heartbeatJob.Register(jobCtx, heartbeatSvc)
 
 		// Self-update job (gated by config)
 		if appconf.SelfUpdateEnabled() {
-			startSelfUpdateJob(ctx)
+			startSelfUpdateJob(jobCtx)
 		}
+
+		<-jobCtx.Done()
 	}()
 
 	return e.Start(fmt.Sprintf(":%s", appconf.Port()))


### PR DESCRIPTION
## Summary

Adds structured telemetry, chaos injection, and configurable harness intervals for the Hostlink WebSocket task delivery path.

### Key changes

- **Structured telemetry**: Emit correlated events and metrics for connection state, reconnect attempts, outbox pending/acked/resend counts, delivery duplicates, output truncation, and ACK latency
- **Chaos injectors**: Deterministic duplicate-output and missing-output-sequence injection at the wsclient seam, controlled by environment variables
- **Configurable harness intervals**: Export env vars for registration retry delay, task poll interval, metrics push interval, heartbeat interval, and output flush interval/threshold to support fast deterministic testing
- **Output-gap replay**: Local store outbox supports retryable output sequence replay with configurable max retries
- **Lifecycle fix**: Local store shutdown ordering fixed so async jobs finish before store closes; reconnect snapshot correctly parses final payload fields (status, exit_code, output, error, truncation flags)

### Testing

- all Go tests pass: taskjob, wsclient, localtaskstore, appconf
- Full Rails real-process suite (selfhost PR #965) validates the combined path end-to-end
