### PR TITLE
fix(test): clear default containercollector stub before custom return

### DIFF
--- a/app/services/metrics/metrics_test.go
+++ b/app/services/metrics/metrics_test.go
@@ -243,6 +243,14 @@ func (m *MockTraefikCollector) Collect(ctx context.Context) ([]traefikmetrics.En
 	return args.Get(0).([]traefikmetrics.EntrypointMetricSet), args.Error(1)
 }
 
+func (m *MockTraefikCollector) CollectRouters(ctx context.Context) ([]traefikmetrics.RouterMetricSet, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]traefikmetrics.RouterMetricSet), args.Error(1)
+}
+
 type MockDockerDiscoverer struct {
 	mock.Mock
 }
@@ -314,6 +322,8 @@ func setupTestMetricsPusher() (*metricspusher, *testMocks) {
 		Return([]containermetrics.ContainerMetricSet(nil), nil)
 	mocks.traefikcollector.On("Collect", mock.Anything).
 		Return([]traefikmetrics.EntrypointMetricSet(nil), nil)
+	mocks.traefikcollector.On("CollectRouters", mock.Anything).
+		Return([]traefikmetrics.RouterMetricSet(nil), nil)
 
 	return mp, mocks
 }

--- a/app/services/metrics/metrics_test.go
+++ b/app/services/metrics/metrics_test.go
@@ -1112,6 +1112,8 @@ func TestPush_ContainerMetrics_IncludesCoolifyName(t *testing.T) {
 	setupPgBouncerCollectorMocks(mocks.pgbouncercollector)
 	mocks.collector.On("Collect", testCred).Return(domainmetrics.PostgreSQLDatabaseMetrics{Up: true}, nil)
 	mocks.storagecollector.On("Collect", mock.Anything).Return([]storagemetrics.StorageMetricSet(nil), nil)
+	// Clear the default nil-returning stub so the custom return below takes effect.
+	mocks.containercollector.ExpectedCalls = nil
 	mocks.containercollector.On("Collect", mock.Anything).Return([]containermetrics.ContainerMetricSet{
 		{
 			Attributes: domainmetrics.ContainerAttributes{

--- a/app/services/wsclient/client_test.go
+++ b/app/services/wsclient/client_test.go
@@ -598,13 +598,20 @@ func TestClientAckRemovesResultMessageFromOutbox(t *testing.T) {
 		messages, err := store.UnackedMessages()
 		return err == nil && len(messages) == 0
 	}, "ack to remove outbox message")
-	entries := telemetryEntries(t, telemetryPath)
-	ackMetric := findTelemetryEntry(entries, func(entry map[string]any) bool {
-		return entry["metric_name"] == "hostlink.local_store.outbox.pending_messages" && entry["value"] == float64(0)
-	})
-	finalPendingAck := findTelemetryEntry(entries, func(entry map[string]any) bool {
-		return entry["event"] == "hostlink.agent_ws.outbox.acknowledged" && entry["acked_message_id"] == "msg-output-1"
-	})
+	var ackMetric map[string]any
+	var finalPendingAck map[string]any
+	waitFor(t, func() bool {
+		entries := telemetryEntries(t, telemetryPath)
+		ackMetric = findTelemetryEntry(entries, func(entry map[string]any) bool {
+			return entry["metric_name"] == "hostlink.local_store.outbox.pending_messages" && entry["value"] == float64(0)
+		})
+		finalPendingAck = findTelemetryEntry(entries, func(entry map[string]any) bool {
+			return entry["event"] == "hostlink.agent_ws.outbox.acknowledged" && entry["acked_message_id"] == "msg-output-1"
+		})
+		return ackMetric["metric_name"] == "hostlink.local_store.outbox.pending_messages" &&
+			finalPendingAck["task_id"] == "task-1" &&
+			finalPendingAck["execution_attempt_id"] == "attempt-1"
+	}, "telemetry for output outbox acknowledgement")
 	if ackMetric["metric_name"] != "hostlink.local_store.outbox.pending_messages" {
 		t.Fatalf("ack metric = %#v", ackMetric)
 	}


### PR DESCRIPTION
setupTestMetricsPusher registers a nil-returning stub for containercollector. Collect. Testify uses the first registered expectation, so any custom Return added by an individual test was silently ignored — the container metrics never appeared in the payload.

Clear ExpectedCalls before registering the test-specific return so the custom data reaches PushMetrics as expected.