### PR TITLE
fix(taskjob): prevent concurrent duplicate execution of the same task

### DIFF
--- a/app/jobs/taskjob/dedup_test.go
+++ b/app/jobs/taskjob/dedup_test.go
@@ -1,0 +1,67 @@
+package taskjob
+
+import (
+	"context"
+	"hostlink/domain/task"
+	"testing"
+	"time"
+)
+
+// TestProcessTaskSkipsConcurrentDuplicateForSameTaskID reproduces the
+// production bug where the same task could be dispatched twice concurrently —
+// once via the WebSocket-enqueue consumer and once via the independent HTTP
+// polling trigger, which keeps re-fetching a task as long as the control
+// plane still reports it as not "completed" (which is true for the entire
+// duration the command is running). Without an in-flight guard, both paths
+// call processTask and spawn a second, overlapping execution of the same
+// command against the same task.
+func TestProcessTaskSkipsConcurrentDuplicateForSameTaskID(t *testing.T) {
+	reporter := &fakeTaskReporter{}
+	job := NewJobWithConf(TaskJobConfig{Trigger: runOnceTrigger})
+	slowTask := task.Task{ID: "dup-task", ExecutionAttemptID: "attempt-1", Command: "sleep 0.1", Status: "pending"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		job.processTask(context.Background(), slowTask, reporter, nil)
+	}()
+
+	// Give the first call time to acquire the in-flight lock and start
+	// executing before the "duplicate dispatch" arrives.
+	time.Sleep(20 * time.Millisecond)
+
+	// Simulates a second, concurrent dispatch of the exact same task (e.g.
+	// the polling trigger fetching it while the WebSocket-enqueued run above
+	// is still in flight). This must return immediately without re-running
+	// the command.
+	start := time.Now()
+	job.processTask(context.Background(), slowTask, reporter, nil)
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("duplicate processTask call took %v, want a near-instant skip", elapsed)
+	}
+
+	<-done
+
+	results := reporter.resultsSnapshot()
+	if len(results) != 1 {
+		t.Fatalf("report count = %d, want 1 (duplicate concurrent dispatch must not re-run the command)", len(results))
+	}
+}
+
+// TestProcessTaskAllowsSequentialReprocessingAfterCompletion ensures the
+// in-flight guard only blocks true concurrency — once a task's execution has
+// finished, a later (non-overlapping) dispatch of the same task ID must still
+// be allowed to run, e.g. for legitimate retries.
+func TestProcessTaskAllowsSequentialReprocessingAfterCompletion(t *testing.T) {
+	reporter := &fakeTaskReporter{}
+	job := NewJobWithConf(TaskJobConfig{Trigger: runOnceTrigger})
+	quickTask := task.Task{ID: "seq-task", Command: "printf ok", Status: "pending"}
+
+	job.processTask(context.Background(), quickTask, reporter, nil)
+	job.processTask(context.Background(), quickTask, reporter, nil)
+
+	results := reporter.resultsSnapshot()
+	if len(results) != 2 {
+		t.Fatalf("report count = %d, want 2 (non-overlapping dispatches of the same task ID must both run)", len(results))
+	}
+}

--- a/app/jobs/taskjob/taskjob.go
+++ b/app/jobs/taskjob/taskjob.go
@@ -43,10 +43,12 @@ type ResultChannel interface {
 }
 
 type TaskJob struct {
-	config    TaskJobConfig
-	enqueueCh chan task.Task
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
+	config     TaskJobConfig
+	enqueueCh  chan task.Task
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	inFlightMu sync.Mutex
+	inFlight   map[string]struct{}
 }
 
 func New() *TaskJob {
@@ -69,7 +71,27 @@ func NewJobWithConf(cfg TaskJobConfig) *TaskJob {
 	return &TaskJob{
 		config:    cfg,
 		enqueueCh: make(chan task.Task, 16),
+		inFlight:  make(map[string]struct{}),
 	}
+}
+
+// acquireTask marks a task as being processed. It returns false if the task
+// is already in flight (dispatched via WebSocket enqueue and via the polling
+// trigger can otherwise race to run the same task's command concurrently).
+func (tj *TaskJob) acquireTask(taskID string) bool {
+	tj.inFlightMu.Lock()
+	defer tj.inFlightMu.Unlock()
+	if _, running := tj.inFlight[taskID]; running {
+		return false
+	}
+	tj.inFlight[taskID] = struct{}{}
+	return true
+}
+
+func (tj *TaskJob) releaseTask(taskID string) {
+	tj.inFlightMu.Lock()
+	defer tj.inFlightMu.Unlock()
+	delete(tj.inFlight, taskID)
 }
 
 func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr taskreporter.TaskReporter, channels ...ResultChannel) context.CancelFunc {
@@ -143,6 +165,12 @@ func (tj *TaskJob) processTaskSafe(ctx context.Context, t task.Task, tr taskrepo
 }
 
 func (tj *TaskJob) processTask(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
+	if !tj.acquireTask(t.ID) {
+		log.Infof("task %s already in flight, skipping duplicate dispatch (execution_attempt_id=%s)", t.ID, t.ExecutionAttemptID)
+		return
+	}
+	defer tj.releaseTask(t.ID)
+
 	tempFile, err := os.CreateTemp("", "*_script.sh")
 	if err != nil {
 		t.Error = fmt.Sprintf("failed to create temp file: %v", err)


### PR DESCRIPTION
The WebSocket-enqueue consumer and the independent HTTP polling trigger both call processTask for a task whenever the control plane hasn't yet reported it "completed" — which is true for the entire duration a long-running command executes. With no shared state between the two paths, they could both start the same command concurrently, racing on any state that command touches (observed in production as duplicate initdb runs corrupting the same data directory).

Add an in-flight registry keyed by task ID, checked and released around processTask, so a task already executing is skipped by any concurrent dispatch instead of re-run. Sequential (non-overlapping) re-dispatch of the same task ID — e.g. legitimate retries — is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/selfhost-dev/codesmith/hostlink/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785774022&installation_id=142051085&pr_number=209&repository=selfhost-dev%2Fhostlink&return_to=https%3A%2F%2Fgithub.com%2Fselfhost-dev%2Fhostlink%2Fpull%2F209&signature=6c05d50fc974da50f8feb1afb1c216c9c442736364556407be343001e9dd4378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->