### PR TITLE
fix(taskjob): dedup Enqueue against already-queued or running tasks

### DIFF
--- a/app/jobs/taskjob/dedup_test.go
+++ b/app/jobs/taskjob/dedup_test.go
@@ -7,61 +7,69 @@ import (
 	"time"
 )
 
-// TestProcessTaskSkipsConcurrentDuplicateForSameTaskID reproduces the
-// production bug where the same task could be dispatched twice concurrently —
-// once via the WebSocket-enqueue consumer and once via the independent HTTP
-// polling trigger, which keeps re-fetching a task as long as the control
-// plane still reports it as not "completed" (which is true for the entire
-// duration the command is running). Without an in-flight guard, both paths
-// call processTask and spawn a second, overlapping execution of the same
-// command against the same task.
-func TestProcessTaskSkipsConcurrentDuplicateForSameTaskID(t *testing.T) {
+// TestEnqueueSkipsDuplicateWhileTaskIsQueuedOrRunning reproduces the
+// production bug: a task delivered without an execution_attempt_id (e.g.
+// via HTTP polling or a heartbeat response) never reports "started" back to
+// the control plane, so it keeps looking "pending" to every caller that
+// re-checks it. Heartbeat re-checks every 5s and, prior to this fix, called
+// Enqueue unconditionally — piling up duplicate, not-yet-started copies of
+// the same task that the single consumer goroutine would later run one
+// after another, long after the task had actually completed.
+func TestEnqueueSkipsDuplicateWhileTaskIsQueuedOrRunning(t *testing.T) {
 	reporter := &fakeTaskReporter{}
 	job := NewJobWithConf(TaskJobConfig{Trigger: runOnceTrigger})
-	slowTask := task.Task{ID: "dup-task", ExecutionAttemptID: "attempt-1", Command: "sleep 0.1", Status: "pending"}
+	slowTask := task.Task{ID: "dup-task", Command: "sleep 0.1", Status: "pending"}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		job.processTask(context.Background(), slowTask, reporter, nil)
-	}()
-
-	// Give the first call time to acquire the in-flight lock and start
-	// executing before the "duplicate dispatch" arrives.
-	time.Sleep(20 * time.Millisecond)
-
-	// Simulates a second, concurrent dispatch of the exact same task (e.g.
-	// the polling trigger fetching it while the WebSocket-enqueued run above
-	// is still in flight). This must return immediately without re-running
-	// the command.
-	start := time.Now()
-	job.processTask(context.Background(), slowTask, reporter, nil)
-	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
-		t.Fatalf("duplicate processTask call took %v, want a near-instant skip", elapsed)
+	// Simulates repeated heartbeat ticks (or polling fetches) all seeing the
+	// same task as "pending" while the first enqueue is still queued/running.
+	for i := 0; i < 5; i++ {
+		if err := job.Enqueue(context.Background(), slowTask); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
 	}
 
-	<-done
+	cancel := job.Register(context.Background(), &fakeTaskFetcher{}, reporter)
+	defer func() {
+		cancel()
+		job.Shutdown()
+	}()
+
+	waitForReports(t, reporter, 1)
+	time.Sleep(50 * time.Millisecond) // give any (wrongly) queued duplicates a chance to also run
 
 	results := reporter.resultsSnapshot()
 	if len(results) != 1 {
-		t.Fatalf("report count = %d, want 1 (duplicate concurrent dispatch must not re-run the command)", len(results))
+		t.Fatalf("report count = %d, want 1 (5 duplicate Enqueue calls for the same in-flight task must only run once)", len(results))
 	}
 }
 
-// TestProcessTaskAllowsSequentialReprocessingAfterCompletion ensures the
-// in-flight guard only blocks true concurrency — once a task's execution has
-// finished, a later (non-overlapping) dispatch of the same task ID must still
-// be allowed to run, e.g. for legitimate retries.
-func TestProcessTaskAllowsSequentialReprocessingAfterCompletion(t *testing.T) {
+// TestEnqueueAllowsReprocessingAfterTaskCompletes ensures the dedup guard
+// only blocks duplicates while a task is queued or running — once it has
+// finished (and released its reservation), a later Enqueue for the same
+// task ID (e.g. a legitimate retry) must still be accepted.
+func TestEnqueueAllowsReprocessingAfterTaskCompletes(t *testing.T) {
 	reporter := &fakeTaskReporter{}
 	job := NewJobWithConf(TaskJobConfig{Trigger: runOnceTrigger})
 	quickTask := task.Task{ID: "seq-task", Command: "printf ok", Status: "pending"}
 
-	job.processTask(context.Background(), quickTask, reporter, nil)
-	job.processTask(context.Background(), quickTask, reporter, nil)
+	cancel := job.Register(context.Background(), &fakeTaskFetcher{}, reporter)
+	defer func() {
+		cancel()
+		job.Shutdown()
+	}()
+
+	if err := job.Enqueue(context.Background(), quickTask); err != nil {
+		t.Fatalf("enqueue 1: %v", err)
+	}
+	waitForReports(t, reporter, 1)
+
+	if err := job.Enqueue(context.Background(), quickTask); err != nil {
+		t.Fatalf("enqueue 2: %v", err)
+	}
+	waitForReports(t, reporter, 2)
 
 	results := reporter.resultsSnapshot()
 	if len(results) != 2 {
-		t.Fatalf("report count = %d, want 2 (non-overlapping dispatches of the same task ID must both run)", len(results))
+		t.Fatalf("report count = %d, want 2 (non-overlapping re-enqueue of the same task ID after completion must run again)", len(results))
 	}
 }

--- a/app/jobs/taskjob/taskjob.go
+++ b/app/jobs/taskjob/taskjob.go
@@ -75,9 +75,11 @@ func NewJobWithConf(cfg TaskJobConfig) *TaskJob {
 	}
 }
 
-// acquireTask marks a task as being processed. It returns false if the task
-// is already in flight (dispatched via WebSocket enqueue and via the polling
-// trigger can otherwise race to run the same task's command concurrently).
+// acquireTask reserves a task ID for execution. It returns false if the
+// task is already queued or running. Reservation happens at Enqueue time
+// (not just when execution actually starts) so that repeated calls from any
+// source — WebSocket push, HTTP polling, or heartbeat responses — can't pile
+// up duplicate, not-yet-started copies of the same task in the queue.
 func (tj *TaskJob) acquireTask(taskID string) bool {
 	tj.inFlightMu.Lock()
 	defer tj.inFlightMu.Unlock()
@@ -131,7 +133,9 @@ func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr 
 				}
 			}
 			for _, t := range incompleteTasks {
-				tj.processTaskSafe(ctx, t, tr, channel)
+				if err := tj.Enqueue(ctx, t); err != nil {
+					log.Errorf("failed to enqueue polled task %s: %v", t.ID, err)
+				}
 			}
 			return nil
 		})
@@ -139,7 +143,18 @@ func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr 
 	return cancel
 }
 
+// Enqueue queues a task for execution. It is the single dedup choke point
+// for all three task sources (WebSocket push, HTTP polling, heartbeat
+// responses): a task ID already queued or currently running is skipped
+// silently rather than queued again. Without this, a task that hasn't yet
+// reported "started" back to the control plane (e.g. anything delivered
+// without an execution_attempt_id) keeps looking "pending" to every caller
+// that re-checks it — heartbeat ticks every 5s — and each one would queue
+// another duplicate run of the same (possibly destructive) command.
 func (tj *TaskJob) Enqueue(ctx context.Context, t task.Task) error {
+	if !tj.acquireTask(t.ID) {
+		return nil
+	}
 	select {
 	case tj.enqueueCh <- t:
 		telemetry.Metric("hostlink.task_runner.queue.depth", len(tj.enqueueCh), map[string]any{
@@ -148,6 +163,7 @@ func (tj *TaskJob) Enqueue(ctx context.Context, t task.Task) error {
 		})
 		return nil
 	case <-ctx.Done():
+		tj.releaseTask(t.ID)
 		return ctx.Err()
 	}
 }
@@ -164,11 +180,12 @@ func (tj *TaskJob) processTaskSafe(ctx context.Context, t task.Task, tr taskrepo
 	tj.processTask(ctx, t, tr, channel)
 }
 
+// processTask runs a task's command. Callers reaching this via Register()
+// (the enqueueCh consumer) have already had the task ID reserved by
+// Enqueue; this only owns releasing that reservation once execution
+// finishes. Direct callers (e.g. tests) that bypass Enqueue don't hold a
+// reservation, so the release below is a harmless no-op for them.
 func (tj *TaskJob) processTask(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
-	if !tj.acquireTask(t.ID) {
-		log.Infof("task %s already in flight, skipping duplicate dispatch (execution_attempt_id=%s)", t.ID, t.ExecutionAttemptID)
-		return
-	}
 	defer tj.releaseTask(t.ID)
 
 	tempFile, err := os.CreateTemp("", "*_script.sh")

--- a/app/jobs/taskjob/taskjob.go
+++ b/app/jobs/taskjob/taskjob.go
@@ -109,7 +109,7 @@ func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr 
 		for {
 			select {
 			case queued := <-tj.enqueueCh:
-				tj.processTaskSafe(ctx, queued, tr, channel)
+				tj.processQueuedTaskSafe(ctx, queued, tr, channel)
 			case <-ctx.Done():
 				return
 			}
@@ -133,9 +133,7 @@ func (tj *TaskJob) Register(ctx context.Context, tf taskfetcher.TaskFetcher, tr 
 				}
 			}
 			for _, t := range incompleteTasks {
-				if err := tj.Enqueue(ctx, t); err != nil {
-					log.Errorf("failed to enqueue polled task %s: %v", t.ID, err)
-				}
+				tj.processTaskSafe(ctx, t, tr, channel)
 			}
 			return nil
 		})
@@ -168,26 +166,51 @@ func (tj *TaskJob) Enqueue(ctx context.Context, t task.Task) error {
 	}
 }
 
-func (tj *TaskJob) processTaskSafe(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
+func panicSafe(taskID string, fn func()) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorf("Panic recovered in processTask: %v", r)
 			telemetry.Metric("hostlink.task_runner.panic", 1, map[string]any{
-				"task_id": t.ID,
+				"task_id": taskID,
 			})
 		}
 	}()
-	tj.processTask(ctx, t, tr, channel)
+	fn()
 }
 
-// processTask runs a task's command. Callers reaching this via Register()
-// (the enqueueCh consumer) have already had the task ID reserved by
-// Enqueue; this only owns releasing that reservation once execution
-// finishes. Direct callers (e.g. tests) that bypass Enqueue don't hold a
-// reservation, so the release below is a harmless no-op for them.
-func (tj *TaskJob) processTask(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
-	defer tj.releaseTask(t.ID)
+// processTaskSafe is for callers that have NOT already reserved the task ID
+// (direct polling-trigger dispatch, tests calling in without Enqueue): it
+// self-guards via processTask before running.
+func (tj *TaskJob) processTaskSafe(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
+	panicSafe(t.ID, func() { tj.processTask(ctx, t, tr, channel) })
+}
 
+// processQueuedTaskSafe is for tasks dequeued from enqueueCh — Enqueue
+// already reserved this task ID before queueing it, so this only owns
+// releasing that reservation once execution finishes, without trying to
+// (and incorrectly failing to) re-acquire it.
+func (tj *TaskJob) processQueuedTaskSafe(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
+	panicSafe(t.ID, func() {
+		defer tj.releaseTask(t.ID)
+		tj.runTask(ctx, t, tr, channel)
+	})
+}
+
+// processTask self-guards against a task ID that's already queued or
+// running elsewhere, then runs it. Used by direct callers that never went
+// through Enqueue (the polling trigger, and tests calling in directly).
+func (tj *TaskJob) processTask(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
+	if !tj.acquireTask(t.ID) {
+		log.Infof("task %s already in flight, skipping duplicate dispatch (execution_attempt_id=%s)", t.ID, t.ExecutionAttemptID)
+		return
+	}
+	defer tj.releaseTask(t.ID)
+	tj.runTask(ctx, t, tr, channel)
+}
+
+// runTask executes a task's command and reports the result. It assumes the
+// caller already owns the task ID's reservation (or doesn't need one).
+func (tj *TaskJob) runTask(ctx context.Context, t task.Task, tr taskreporter.TaskReporter, channel ResultChannel) {
 	tempFile, err := os.CreateTemp("", "*_script.sh")
 	if err != nil {
 		t.Error = fmt.Sprintf("failed to create temp file: %v", err)


### PR DESCRIPTION
HeartbeatJob.enqueueTasks (and, previously, the polling trigger) called Enqueue directly with no check against work already queued or in flight. A task delivered without an execution_attempt_id (HTTP polling or a heartbeat response) never reports "started" back to the control plane, so it keeps looking "pending" to every caller that re-checks it. Heartbeat re-checks every 5s, so each tick queued another duplicate copy of the same task — observed in production as the same install/ replication script re-running destructively for minutes after the control plane had already marked the task completed.

Move the dedup reservation from processTask (execution start) to Enqueue (queue time), so a task already queued-but-not-started is rejected too, not just one already running. This closes the gap for all three task sources — WebSocket push, HTTP polling, and heartbeat — through a single choke point. The polling trigger now goes through Enqueue as well, instead of calling processTask directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/selfhost-dev/codesmith/hostlink/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785780367&installation_id=142051085&pr_number=210&repository=selfhost-dev%2Fhostlink&return_to=https%3A%2F%2Fgithub.com%2Fselfhost-dev%2Fhostlink%2Fpull%2F210&signature=548b0749740f2efb67b8aecc010909d239396d5d886f497a73ea9ed748e6387a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->