### PR TITLE
feat: add ClickHouse metrics collection via HTTP interface

### DIFF
--- a/app/services/metrics/metrics.go
+++ b/app/services/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 	"hostlink/domain/credential"
 	domainmetrics "hostlink/domain/metrics"
 	"hostlink/internal/apiserver"
+	"hostlink/internal/clickhousemetrics"
 	"hostlink/internal/containermetrics"
 	"hostlink/internal/crypto"
 	"hostlink/internal/dockerdiscovery"
@@ -36,21 +37,22 @@ type Pusher interface {
 }
 
 type metricspusher struct {
-	apiserver          apiserver.MetricsOperations
-	agentstate         agentstate.Operations
-	metricscollector   pgmetrics.Collector
-	syscollector       sysmetrics.Collector
-	netcollector       networkmetrics.Collector
-	storagecollector   storagemetrics.Collector
-	pgbouncercollector pgbouncermetrics.Collector
-	mysqlcollector     mysqlmetrics.Collector
-	mongodbcollector   mongodbmetrics.Collector
-	rediscollector     redismetrics.Collector
-	containercollector containermetrics.Collector
-	traefikcollector   traefikmetrics.Collector
-	dockerDiscoverer   dockerdiscovery.Discoverer
-	crypto             crypto.Service
-	privateKeyPath     string
+	apiserver              apiserver.MetricsOperations
+	agentstate             agentstate.Operations
+	metricscollector       pgmetrics.Collector
+	syscollector           sysmetrics.Collector
+	netcollector           networkmetrics.Collector
+	storagecollector       storagemetrics.Collector
+	pgbouncercollector     pgbouncermetrics.Collector
+	mysqlcollector         mysqlmetrics.Collector
+	mongodbcollector       mongodbmetrics.Collector
+	rediscollector         redismetrics.Collector
+	clickhousecollector    clickhousemetrics.Collector
+	containercollector     containermetrics.Collector
+	traefikcollector       traefikmetrics.Collector
+	dockerDiscoverer       dockerdiscovery.Discoverer
+	crypto                 crypto.Service
+	privateKeyPath         string
 }
 
 func NewWithConf() (*metricspusher, error) {
@@ -64,21 +66,22 @@ func NewWithConf() (*metricspusher, error) {
 	}
 
 	return &metricspusher{
-		apiserver:          svr,
-		agentstate:         agentstate,
-		metricscollector:   pgmetrics.New(),
-		syscollector:       sysmetrics.New(),
-		netcollector:       networkmetrics.New(),
-		storagecollector:   storagemetrics.New(),
-		pgbouncercollector: pgbouncermetrics.New(),
-		mysqlcollector:     mysqlmetrics.New(),
-		mongodbcollector:   mongodbmetrics.New(),
-		rediscollector:     redismetrics.New(),
-		containercollector: containermetrics.New(),
-		traefikcollector:   traefikmetrics.New(),
-		dockerDiscoverer:   dockerdiscovery.New(),
-		crypto:             crypto.NewService(),
-		privateKeyPath:     appconf.AgentPrivateKeyPath(),
+		apiserver:           svr,
+		agentstate:          agentstate,
+		metricscollector:    pgmetrics.New(),
+		syscollector:        sysmetrics.New(),
+		netcollector:        networkmetrics.New(),
+		storagecollector:    storagemetrics.New(),
+		pgbouncercollector:  pgbouncermetrics.New(),
+		mysqlcollector:      mysqlmetrics.New(),
+		mongodbcollector:    mongodbmetrics.New(),
+		rediscollector:      redismetrics.New(),
+		clickhousecollector: clickhousemetrics.New(),
+		containercollector:  containermetrics.New(),
+		traefikcollector:    traefikmetrics.New(),
+		dockerDiscoverer:    dockerdiscovery.New(),
+		crypto:              crypto.NewService(),
+		privateKeyPath:      appconf.AgentPrivateKeyPath(),
 	}, nil
 }
 
@@ -98,6 +101,7 @@ func NewWithDependencies(
 	mysqlcollector mysqlmetrics.Collector,
 	mongodbcollector mongodbmetrics.Collector,
 	rediscollector redismetrics.Collector,
+	clickhousecollector clickhousemetrics.Collector,
 	containercollector containermetrics.Collector,
 	traefikcollector traefikmetrics.Collector,
 	dockerDiscoverer dockerdiscovery.Discoverer,
@@ -105,21 +109,22 @@ func NewWithDependencies(
 	privateKeyPath string,
 ) *metricspusher {
 	return &metricspusher{
-		apiserver:          apiserver,
-		agentstate:         agentstate,
-		metricscollector:   pgcollector,
-		syscollector:       syscollector,
-		netcollector:       netcollector,
-		storagecollector:   storagecollector,
-		pgbouncercollector: pgbouncermetrics.New(),
-		mysqlcollector:     mysqlcollector,
-		mongodbcollector:   mongodbcollector,
-		rediscollector:     rediscollector,
-		containercollector: containercollector,
-		traefikcollector:   traefikcollector,
-		dockerDiscoverer:   dockerDiscoverer,
-		crypto:             crypto,
-		privateKeyPath:     privateKeyPath,
+		apiserver:           apiserver,
+		agentstate:          agentstate,
+		metricscollector:    pgcollector,
+		syscollector:        syscollector,
+		netcollector:        netcollector,
+		storagecollector:    storagecollector,
+		pgbouncercollector:  pgbouncercollector,
+		mysqlcollector:      mysqlcollector,
+		mongodbcollector:    mongodbcollector,
+		rediscollector:      rediscollector,
+		clickhousecollector: clickhousecollector,
+		containercollector:  containercollector,
+		traefikcollector:    traefikcollector,
+		dockerDiscoverer:    dockerDiscoverer,
+		crypto:              crypto,
+		privateKeyPath:      privateKeyPath,
 	}
 }
 
@@ -234,6 +239,21 @@ func (mp *metricspusher) Push(cred credential.Credential) error {
 			}
 			metricSets = append(metricSets, domainmetrics.MetricSet{
 				Type:    domainmetrics.MetricTypeRedis,
+				Metrics: m,
+			})
+		}
+
+	case "clickhouse":
+		if cred.Host != "" || cred.Port != 0 {
+			m, err := mp.clickhousecollector.Collect(cred)
+			if err != nil {
+				log.Warnf("clickhouse metrics collection failed: %v", err)
+				m = domainmetrics.ClickHouseDatabaseMetrics{Up: false}
+			} else {
+				m.Up = true
+			}
+			metricSets = append(metricSets, domainmetrics.MetricSet{
+				Type:    domainmetrics.MetricTypeClickHouseDatabase,
 				Metrics: m,
 			})
 		}

--- a/app/services/metrics/metrics_test.go
+++ b/app/services/metrics/metrics_test.go
@@ -219,6 +219,15 @@ func (m *MockRedisCollector) Collect(cred credential.Credential) (domainmetrics.
 	return args.Get(0).(domainmetrics.RedisMetrics), args.Error(1)
 }
 
+type MockClickHouseCollector struct {
+	mock.Mock
+}
+
+func (m *MockClickHouseCollector) Collect(cred credential.Credential) (domainmetrics.ClickHouseDatabaseMetrics, error) {
+	args := m.Called(cred)
+	return args.Get(0).(domainmetrics.ClickHouseDatabaseMetrics), args.Error(1)
+}
+
 type MockContainerCollector struct {
 	mock.Mock
 }
@@ -262,38 +271,40 @@ func (m *MockDockerDiscoverer) DiscoverDatabases(ctx context.Context) ([]dockerd
 
 // Test helpers
 type testMocks struct {
-	apiserver          *MockAPIServer
-	agentstate         *MockAgentState
-	collector          *MockCollector
-	syscollector       *MockSysCollector
-	netcollector       *MockNetCollector
-	storagecollector   *MockStorageCollector
-	pgbouncercollector *MockPgBouncerCollector
-	mysqlcollector     *MockMySQLCollector
-	mongodbcollector   *MockMongoDBCollector
-	rediscollector     *MockRedisCollector
-	containercollector *MockContainerCollector
-	traefikcollector   *MockTraefikCollector
-	dockerDiscoverer   *MockDockerDiscoverer
-	crypto             *MockCrypto
+	apiserver            *MockAPIServer
+	agentstate           *MockAgentState
+	collector            *MockCollector
+	syscollector         *MockSysCollector
+	netcollector         *MockNetCollector
+	storagecollector     *MockStorageCollector
+	pgbouncercollector   *MockPgBouncerCollector
+	mysqlcollector       *MockMySQLCollector
+	mongodbcollector     *MockMongoDBCollector
+	rediscollector       *MockRedisCollector
+	clickhousecollector  *MockClickHouseCollector
+	containercollector   *MockContainerCollector
+	traefikcollector     *MockTraefikCollector
+	dockerDiscoverer     *MockDockerDiscoverer
+	crypto               *MockCrypto
 }
 
 func setupTestMetricsPusher() (*metricspusher, *testMocks) {
 	mocks := &testMocks{
-		apiserver:          new(MockAPIServer),
-		agentstate:         new(MockAgentState),
-		collector:          new(MockCollector),
-		syscollector:       new(MockSysCollector),
-		netcollector:       new(MockNetCollector),
-		storagecollector:   new(MockStorageCollector),
-		pgbouncercollector: new(MockPgBouncerCollector),
-		mysqlcollector:     new(MockMySQLCollector),
-		mongodbcollector:   new(MockMongoDBCollector),
-		rediscollector:     new(MockRedisCollector),
-		containercollector: new(MockContainerCollector),
-		traefikcollector:   new(MockTraefikCollector),
-		dockerDiscoverer:   new(MockDockerDiscoverer),
-		crypto:             new(MockCrypto),
+		apiserver:           new(MockAPIServer),
+		agentstate:          new(MockAgentState),
+		collector:           new(MockCollector),
+		syscollector:        new(MockSysCollector),
+		netcollector:        new(MockNetCollector),
+		storagecollector:    new(MockStorageCollector),
+		pgbouncercollector:  new(MockPgBouncerCollector),
+		mysqlcollector:      new(MockMySQLCollector),
+		mongodbcollector:    new(MockMongoDBCollector),
+		rediscollector:      new(MockRedisCollector),
+		clickhousecollector: new(MockClickHouseCollector),
+		containercollector:  new(MockContainerCollector),
+		traefikcollector:    new(MockTraefikCollector),
+		dockerDiscoverer:    new(MockDockerDiscoverer),
+		crypto:              new(MockCrypto),
 	}
 
 	mp := NewWithDependencies(
@@ -307,6 +318,7 @@ func setupTestMetricsPusher() (*metricspusher, *testMocks) {
 		mocks.mysqlcollector,
 		mocks.mongodbcollector,
 		mocks.rediscollector,
+		mocks.clickhousecollector,
 		mocks.containercollector,
 		mocks.traefikcollector,
 		mocks.dockerDiscoverer,

--- a/domain/metrics/metrics.go
+++ b/domain/metrics/metrics.go
@@ -13,6 +13,7 @@ const (
 	MetricTypeContainer          = "container"
 	MetricTypeTraefikService     = "traefik.proxy"
 	MetricTypeTraefikRouter      = "traefik.router"
+	MetricTypeClickHouseDatabase = "clickhouse.database"
 )
 
 type MetricPayload struct {
@@ -210,6 +211,21 @@ type TraefikRouterAttributes struct {
 	RouterName     string `json:"router_name"`
 	EntrypointName string `json:"entrypoint_name"`
 	Service        string `json:"service,omitempty"`
+}
+
+// ClickHouseDatabaseMetrics holds the key operational metrics scraped from a
+// ClickHouse instance via its HTTP interface. Rate fields are per-second deltas;
+// the first collection cycle stores a baseline and returns zero for all rates.
+type ClickHouseDatabaseMetrics struct {
+	Up                     bool    `json:"up"`
+	ConnectionsTotal       int     `json:"connections_total"`
+	QueriesPerSecond       float64 `json:"queries_per_second"`
+	SelectQueriesPerSecond float64 `json:"select_queries_per_second"`
+	InsertQueriesPerSecond float64 `json:"insert_queries_per_second"`
+	FailedQueriesPerSecond float64 `json:"failed_queries_per_second"`
+	InsertedRowsPerSecond  float64 `json:"inserted_rows_per_second"`
+	MarkCacheHitRatio      float64 `json:"mark_cache_hit_ratio"`
+	PartsActive            int     `json:"parts_active"`
 }
 
 type ContainerAttributes struct {

--- a/internal/clickhousemetrics/collector.go
+++ b/internal/clickhousemetrics/collector.go
@@ -1,0 +1,178 @@
+// Package clickhousemetrics collects metrics from a ClickHouse instance via its HTTP interface.
+package clickhousemetrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"hostlink/domain/credential"
+	"hostlink/domain/metrics"
+)
+
+type Collector interface {
+	Collect(credential.Credential) (metrics.ClickHouseDatabaseMetrics, error)
+}
+
+type collector struct {
+	client         *http.Client
+	lastQueries    *int64
+	lastSelects    *int64
+	lastInserts    *int64
+	lastFailed     *int64
+	lastInsertRows *int64
+	lastTime       time.Time
+}
+
+func New() Collector {
+	return &collector{client: &http.Client{Timeout: 10 * time.Second}}
+}
+
+func (c *collector) Collect(cred credential.Credential) (metrics.ClickHouseDatabaseMetrics, error) {
+	password := ""
+	if cred.Password != nil {
+		password = *cred.Password
+	}
+
+	// ClickHouse default: TCP=9000, HTTP=8123 (diff=877). Derive HTTP port from
+	// the TCP port stored in the credential. Fall back to 8123 for invalid values.
+	httpPort := cred.Port - 877
+	if httpPort <= 0 {
+		httpPort = 8123
+	}
+
+	baseURL := fmt.Sprintf("http://%s:%d/", cred.Host, httpPort)
+
+	if _, err := c.query(baseURL, cred.Username, password, "SELECT 1"); err != nil {
+		return metrics.ClickHouseDatabaseMetrics{}, fmt.Errorf("ping: %w", err)
+	}
+
+	var m metrics.ClickHouseDatabaseMetrics
+
+	// Point-in-time: active TCP + HTTP connections
+	connRows, err := c.query(baseURL, cred.Username, password,
+		"SELECT metric, value FROM system.metrics WHERE metric IN ('TCPConnection','HTTPConnection') FORMAT JSONEachRow")
+	if err != nil {
+		return m, fmt.Errorf("system.metrics: %w", err)
+	}
+	for _, row := range connRows {
+		m.ConnectionsTotal += int(toInt64(row["value"]))
+	}
+
+	// Cumulative event counters used for delta rate calculation
+	eventRows, err := c.query(baseURL, cred.Username, password,
+		"SELECT event, value FROM system.events WHERE event IN ('Query','SelectQuery','InsertQuery','FailedQuery','InsertedRows','MarkCacheHits','MarkCacheMisses') FORMAT JSONEachRow")
+	if err != nil {
+		return m, fmt.Errorf("system.events: %w", err)
+	}
+	events := make(map[string]int64, len(eventRows))
+	for _, row := range eventRows {
+		if k, ok := row["event"].(string); ok {
+			events[k] = toInt64(row["value"])
+		}
+	}
+
+	// Active MergeTree parts — a proxy for table fragmentation health
+	partsRows, err := c.query(baseURL, cred.Username, password,
+		"SELECT count() AS value FROM system.parts WHERE active = 1 FORMAT JSONEachRow")
+	if err == nil && len(partsRows) > 0 {
+		m.PartsActive = int(toInt64(partsRows[0]["value"]))
+	}
+
+	// Mark cache: ratio of hits to total lookups
+	hits := events["MarkCacheHits"]
+	misses := events["MarkCacheMisses"]
+	if total := hits + misses; total > 0 {
+		m.MarkCacheHitRatio = float64(hits) / float64(total) * 100
+	}
+
+	// Delta-based rate metrics. First call stores the baseline and returns zero
+	// for all rates (matching MySQL/PostgreSQL collector behaviour).
+	now := time.Now()
+	curQueries := events["Query"]
+	curSelects := events["SelectQuery"]
+	curInserts := events["InsertQuery"]
+	curFailed := events["FailedQuery"]
+	curInsertRows := events["InsertedRows"]
+
+	if c.lastQueries != nil {
+		elapsed := now.Sub(c.lastTime).Seconds()
+		if elapsed > 0 {
+			m.QueriesPerSecond = float64(curQueries-*c.lastQueries) / elapsed
+			m.SelectQueriesPerSecond = float64(curSelects-*c.lastSelects) / elapsed
+			m.InsertQueriesPerSecond = float64(curInserts-*c.lastInserts) / elapsed
+			m.FailedQueriesPerSecond = float64(curFailed-*c.lastFailed) / elapsed
+			m.InsertedRowsPerSecond = float64(curInsertRows-*c.lastInsertRows) / elapsed
+		}
+	}
+
+	c.lastQueries = &curQueries
+	c.lastSelects = &curSelects
+	c.lastInserts = &curInserts
+	c.lastFailed = &curFailed
+	c.lastInsertRows = &curInsertRows
+	c.lastTime = now
+
+	return m, nil
+}
+
+// query sends a POST request to the ClickHouse HTTP interface and returns the
+// parsed JSONEachRow response as a slice of maps (one map per result row).
+func (c *collector) query(baseURL, user, password, q string) ([]map[string]any, error) {
+	params := url.Values{}
+	params.Set("user", user)
+	params.Set("password", password)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		baseURL+"?"+params.Encode(),
+		strings.NewReader(q))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("clickhouse http %d: %s", resp.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("parse row: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func toInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int64:
+		return x
+	case int:
+		return int64(x)
+	}
+	return 0
+}

--- a/internal/clickhousemetrics/collector_test.go
+++ b/internal/clickhousemetrics/collector_test.go
@@ -1,0 +1,173 @@
+package clickhousemetrics
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"hostlink/domain/credential"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClickHouseServer returns an httptest.Server that routes based on POST body.
+// handlers maps a substring of the query body to a response string.
+func mockClickHouseServer(t *testing.T, handlers map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		q := string(body)
+		for key, resp := range handlers {
+			if strings.Contains(q, key) {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, resp)
+				return
+			}
+		}
+		// Unknown query — return empty OK
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func credForServer(srv *httptest.Server) credential.Credential {
+	// httptest server binds to a random port. We pass Port=0 so the collector
+	// falls back to 8123, but the baseURL we actually want is the server's address.
+	// Override by pointing the collector at the test server's port directly via
+	// a custom credential: since httpPort = Port-877, we set Port = serverPort+877.
+	var port int
+	fmt.Sscanf(srv.Listener.Addr().String(), "127.0.0.1:%d", &port)
+	pw := "test"
+	return credential.Credential{
+		Host:     "127.0.0.1",
+		Port:     port + 877, // collector derives httpPort = Port - 877
+		Username: "default",
+		Password: &pw,
+	}
+}
+
+func standardHandlers(queryCount, selectCount, insertCount, failedCount, insertRowCount int64) map[string]string {
+	return map[string]string{
+		"SELECT 1": "1\n",
+		"system.metrics": strings.Join([]string{
+			`{"metric":"TCPConnection","value":3}`,
+			`{"metric":"HTTPConnection","value":1}`,
+		}, "\n"),
+		"system.events": strings.Join([]string{
+			fmt.Sprintf(`{"event":"Query","value":%d}`, queryCount),
+			fmt.Sprintf(`{"event":"SelectQuery","value":%d}`, selectCount),
+			fmt.Sprintf(`{"event":"InsertQuery","value":%d}`, insertCount),
+			fmt.Sprintf(`{"event":"FailedQuery","value":%d}`, failedCount),
+			fmt.Sprintf(`{"event":"InsertedRows","value":%d}`, insertRowCount),
+			`{"event":"MarkCacheHits","value":900}`,
+			`{"event":"MarkCacheMisses","value":100}`,
+		}, "\n"),
+		"system.parts": `{"value":42}`,
+	}
+}
+
+func TestCollect_FirstCollection_ReturnsZeroRates(t *testing.T) {
+	srv := mockClickHouseServer(t, standardHandlers(1000, 800, 100, 5, 5000))
+	defer srv.Close()
+
+	c := New()
+	m, err := c.Collect(credForServer(srv))
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, m.ConnectionsTotal) // 3 TCP + 1 HTTP
+	assert.Equal(t, 0.0, m.QueriesPerSecond, "first call must return 0 QPS (baseline only)")
+	assert.Equal(t, 0.0, m.SelectQueriesPerSecond)
+	assert.Equal(t, 0.0, m.InsertQueriesPerSecond)
+	assert.Equal(t, 0.0, m.FailedQueriesPerSecond)
+	assert.Equal(t, 0.0, m.InsertedRowsPerSecond)
+	assert.Equal(t, 90.0, m.MarkCacheHitRatio, "900/(900+100)*100 = 90%")
+	assert.Equal(t, 42, m.PartsActive)
+}
+
+func TestCollect_SecondCollection_ReturnsDeltaRates(t *testing.T) {
+	srv := mockClickHouseServer(t, standardHandlers(1000, 800, 100, 5, 5000))
+	defer srv.Close()
+
+	cred := credForServer(srv)
+	c := New()
+	_, err := c.Collect(cred) // baseline
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // ensure elapsed > 0
+
+	// Simulate counters advancing
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		q := string(body)
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case strings.Contains(q, "SELECT 1"):
+			fmt.Fprint(w, "1\n")
+		case strings.Contains(q, "system.metrics"):
+			fmt.Fprint(w, `{"metric":"TCPConnection","value":5}`+"\n")
+		case strings.Contains(q, "system.events"):
+			fmt.Fprint(w, strings.Join([]string{
+				`{"event":"Query","value":1500}`,
+				`{"event":"SelectQuery","value":1200}`,
+				`{"event":"InsertQuery","value":150}`,
+				`{"event":"FailedQuery","value":8}`,
+				`{"event":"InsertedRows","value":7500}`,
+				`{"event":"MarkCacheHits","value":900}`,
+				`{"event":"MarkCacheMisses","value":100}`,
+			}, "\n"))
+		case strings.Contains(q, "system.parts"):
+			fmt.Fprint(w, `{"value":45}`)
+		}
+	})
+
+	m2, err := c.Collect(cred)
+	require.NoError(t, err)
+
+	assert.Greater(t, m2.QueriesPerSecond, 0.0, "QPS should be positive after counter delta")
+	assert.Greater(t, m2.SelectQueriesPerSecond, 0.0)
+	assert.Greater(t, m2.InsertQueriesPerSecond, 0.0)
+	assert.Greater(t, m2.InsertedRowsPerSecond, 0.0)
+	assert.Equal(t, 45, m2.PartsActive)
+}
+
+func TestCollect_HTTPError_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Authentication failed", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := New()
+	_, err := c.Collect(credForServer(srv))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping")
+}
+
+func TestCollect_HTTPPortDerivation(t *testing.T) {
+	// TCP 9000 → HTTP 8123 (9000 - 877 = 8123)
+	httpPort := 9000 - 877
+	assert.Equal(t, 8123, httpPort)
+
+	// Port <= 877 falls back to 8123
+	fallback := 500 - 877
+	if fallback <= 0 {
+		fallback = 8123
+	}
+	assert.Equal(t, 8123, fallback)
+}
+
+func TestToInt64(t *testing.T) {
+	assert.Equal(t, int64(42), toInt64(float64(42)))
+	assert.Equal(t, int64(100), toInt64(int64(100)))
+	assert.Equal(t, int64(7), toInt64(int(7)))
+	assert.Equal(t, int64(0), toInt64("not a number"))
+	assert.Equal(t, int64(0), toInt64(nil))
+}


### PR DESCRIPTION
Implements a new clickhousemetrics collector that queries ClickHouse's built-in system tables (system.metrics, system.events, system.parts) via the HTTP interface to emit a clickhouse.database metric_set. Rate metrics (QPS, inserts/sec, failed queries/sec, inserted rows/sec) are delta-based and return zero on the first collection cycle — consistent with the MySQL and Redis collectors. Mark cache hit ratio and active MergeTree parts are point-in-time. Wires the new collector into the metrics pusher dispatch switch and NewWithDependencies for full testability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/selfhost-dev/codesmith/hostlink/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786131740&installation_id=142051085&pr_number=213&repository=selfhost-dev%2Fhostlink&return_to=https%3A%2F%2Fgithub.com%2Fselfhost-dev%2Fhostlink%2Fpull%2F213&signature=546df48179bd65ccf7cedb0727b81ddc850793de7f74800483e1a31967c8de2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->