### PR TITLE
feat: add OpenSearch metrics collector

### DIFF
--- a/app/services/metrics/metrics.go
+++ b/app/services/metrics/metrics.go
@@ -15,6 +15,7 @@ import (
 	"hostlink/internal/apiserver"
 	"hostlink/internal/clickhousemetrics"
 	"hostlink/internal/containermetrics"
+	"hostlink/internal/opensearchmetrics"
 	"hostlink/internal/crypto"
 	"hostlink/internal/dockerdiscovery"
 	"hostlink/internal/mongodbmetrics"
@@ -48,6 +49,7 @@ type metricspusher struct {
 	mongodbcollector       mongodbmetrics.Collector
 	rediscollector         redismetrics.Collector
 	clickhousecollector    clickhousemetrics.Collector
+	opensearchcollector    opensearchmetrics.Collector
 	containercollector     containermetrics.Collector
 	traefikcollector       traefikmetrics.Collector
 	dockerDiscoverer       dockerdiscovery.Discoverer
@@ -77,6 +79,7 @@ func NewWithConf() (*metricspusher, error) {
 		mongodbcollector:    mongodbmetrics.New(),
 		rediscollector:      redismetrics.New(),
 		clickhousecollector: clickhousemetrics.New(),
+		opensearchcollector: opensearchmetrics.New(),
 		containercollector:  containermetrics.New(),
 		traefikcollector:    traefikmetrics.New(),
 		dockerDiscoverer:    dockerdiscovery.New(),
@@ -102,6 +105,7 @@ func NewWithDependencies(
 	mongodbcollector mongodbmetrics.Collector,
 	rediscollector redismetrics.Collector,
 	clickhousecollector clickhousemetrics.Collector,
+	opensearchcollector opensearchmetrics.Collector,
 	containercollector containermetrics.Collector,
 	traefikcollector traefikmetrics.Collector,
 	dockerDiscoverer dockerdiscovery.Discoverer,
@@ -120,6 +124,7 @@ func NewWithDependencies(
 		mongodbcollector:    mongodbcollector,
 		rediscollector:      rediscollector,
 		clickhousecollector: clickhousecollector,
+		opensearchcollector: opensearchcollector,
 		containercollector:  containercollector,
 		traefikcollector:    traefikcollector,
 		dockerDiscoverer:    dockerDiscoverer,
@@ -254,6 +259,21 @@ func (mp *metricspusher) Push(cred credential.Credential) error {
 			}
 			metricSets = append(metricSets, domainmetrics.MetricSet{
 				Type:    domainmetrics.MetricTypeClickHouseDatabase,
+				Metrics: m,
+			})
+		}
+
+	case "opensearch":
+		if cred.Host != "" || cred.Port != 0 {
+			m, err := mp.opensearchcollector.Collect(cred)
+			if err != nil {
+				log.Warnf("opensearch metrics collection failed: %v", err)
+				m = domainmetrics.OpenSearchDatabaseMetrics{Up: false, ClusterStatus: 2}
+			} else {
+				m.Up = true
+			}
+			metricSets = append(metricSets, domainmetrics.MetricSet{
+				Type:    domainmetrics.MetricTypeOpenSearchDatabase,
 				Metrics: m,
 			})
 		}

--- a/app/services/metrics/metrics_test.go
+++ b/app/services/metrics/metrics_test.go
@@ -228,6 +228,15 @@ func (m *MockClickHouseCollector) Collect(cred credential.Credential) (domainmet
 	return args.Get(0).(domainmetrics.ClickHouseDatabaseMetrics), args.Error(1)
 }
 
+type MockOpenSearchCollector struct {
+	mock.Mock
+}
+
+func (m *MockOpenSearchCollector) Collect(cred credential.Credential) (domainmetrics.OpenSearchDatabaseMetrics, error) {
+	args := m.Called(cred)
+	return args.Get(0).(domainmetrics.OpenSearchDatabaseMetrics), args.Error(1)
+}
+
 type MockContainerCollector struct {
 	mock.Mock
 }
@@ -282,6 +291,7 @@ type testMocks struct {
 	mongodbcollector     *MockMongoDBCollector
 	rediscollector       *MockRedisCollector
 	clickhousecollector  *MockClickHouseCollector
+	opensearchcollector  *MockOpenSearchCollector
 	containercollector   *MockContainerCollector
 	traefikcollector     *MockTraefikCollector
 	dockerDiscoverer     *MockDockerDiscoverer
@@ -301,6 +311,7 @@ func setupTestMetricsPusher() (*metricspusher, *testMocks) {
 		mongodbcollector:    new(MockMongoDBCollector),
 		rediscollector:      new(MockRedisCollector),
 		clickhousecollector: new(MockClickHouseCollector),
+		opensearchcollector: new(MockOpenSearchCollector),
 		containercollector:  new(MockContainerCollector),
 		traefikcollector:    new(MockTraefikCollector),
 		dockerDiscoverer:    new(MockDockerDiscoverer),
@@ -319,6 +330,7 @@ func setupTestMetricsPusher() (*metricspusher, *testMocks) {
 		mocks.mongodbcollector,
 		mocks.rediscollector,
 		mocks.clickhousecollector,
+		mocks.opensearchcollector,
 		mocks.containercollector,
 		mocks.traefikcollector,
 		mocks.dockerDiscoverer,

--- a/domain/metrics/metrics.go
+++ b/domain/metrics/metrics.go
@@ -13,7 +13,8 @@ const (
 	MetricTypeContainer          = "container"
 	MetricTypeTraefikService     = "traefik.proxy"
 	MetricTypeTraefikRouter      = "traefik.router"
-	MetricTypeClickHouseDatabase = "clickhouse.database"
+	MetricTypeClickHouseDatabase  = "clickhouse.database"
+	MetricTypeOpenSearchDatabase  = "opensearch.database"
 )
 
 type MetricPayload struct {
@@ -217,6 +218,29 @@ type TraefikRouterAttributes struct {
 	RouterName     string `json:"router_name"`
 	EntrypointName string `json:"entrypoint_name"`
 	Service        string `json:"service,omitempty"`
+}
+
+// OpenSearchDatabaseMetrics holds key operational metrics scraped from an
+// OpenSearch cluster via its REST API. ClusterStatus is encoded as an integer
+// (0=green, 1=yellow, 2=red) so that numeric alert rules can be evaluated
+// against it (e.g. cluster_status > 0 means not green). Rate fields
+// (IndexingRate, SearchRate) are per-second deltas; the first collection cycle
+// stores a baseline and returns zero for all rates.
+type OpenSearchDatabaseMetrics struct {
+	Up                    bool    `json:"up"`
+	ClusterStatus         int     `json:"cluster_status"`
+	ActiveShards          int     `json:"active_shards"`
+	RelocatingShards      int     `json:"relocating_shards"`
+	InitializingShards    int     `json:"initializing_shards"`
+	UnassignedShards      int     `json:"unassigned_shards"`
+	ActivePrimaryShards   int     `json:"active_primary_shards"`
+	NumberOfNodes         int     `json:"number_of_nodes"`
+	JvmHeapUsedPercent    float64 `json:"jvm_heap_used_percent"`
+	CPUPercent            float64 `json:"cpu_percent"`
+	DiskUsedPercent       float64 `json:"disk_used_percent"`
+	IndexingRate          float64 `json:"indexing_rate"`
+	SearchRate            float64 `json:"search_rate"`
+	ReplicationLagSeconds int     `json:"replication_lag_seconds"`
 }
 
 // ClickHouseDatabaseMetrics holds the key operational metrics scraped from a

--- a/internal/opensearchmetrics/collector.go
+++ b/internal/opensearchmetrics/collector.go
@@ -1,0 +1,243 @@
+// Package opensearchmetrics collects metrics from an OpenSearch cluster via its REST API.
+package opensearchmetrics
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"hostlink/domain/credential"
+	"hostlink/domain/metrics"
+)
+
+// Collector collects OpenSearch cluster metrics from a single node endpoint.
+// All nodes are queried from that one endpoint — the cluster aggregates internally.
+type Collector interface {
+	Collect(credential.Credential) (metrics.OpenSearchDatabaseMetrics, error)
+}
+
+type collector struct {
+	client          *http.Client
+	lastIndexTotal  *int64
+	lastSearchTotal *int64
+	lastTime        time.Time
+}
+
+// New returns a Collector that skips TLS verification. OpenSearch ships with
+// self-signed demo certificates, so certificate verification is intentionally
+// disabled — the traffic is still encrypted.
+func New() Collector {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	}
+	return &collector{
+		client: &http.Client{Timeout: 10 * time.Second, Transport: transport},
+	}
+}
+
+func (c *collector) Collect(cred credential.Credential) (metrics.OpenSearchDatabaseMetrics, error) {
+	password := ""
+	if cred.Password != nil {
+		password = *cred.Password
+	}
+
+	port := cred.Port
+	if port == 0 {
+		port = 9200
+	}
+
+	baseURL := fmt.Sprintf("https://%s:%d", cred.Host, port)
+
+	// ── 1. Cluster health — primary signal ────────────────────────────────
+	health, err := c.clusterHealth(baseURL, cred.Username, password)
+	if err != nil {
+		return metrics.OpenSearchDatabaseMetrics{}, fmt.Errorf("cluster health: %w", err)
+	}
+
+	var m metrics.OpenSearchDatabaseMetrics
+	m.ClusterStatus = encodeStatus(stringVal(health["status"]))
+	m.ActiveShards = intVal(health["active_shards"])
+	m.RelocatingShards = intVal(health["relocating_shards"])
+	m.InitializingShards = intVal(health["initializing_shards"])
+	m.UnassignedShards = intVal(health["unassigned_shards"])
+	m.ActivePrimaryShards = intVal(health["active_primary_shards"])
+	m.NumberOfNodes = intVal(health["number_of_nodes"])
+
+	// ── 2. Node stats — best-effort; partial failure is tolerated ─────────
+	nodes, err := c.nodeStats(baseURL, cred.Username, password)
+	if err != nil {
+		// Return what we collected from cluster health — enough for basic alerting.
+		return m, nil
+	}
+
+	var (
+		totalHeap      float64
+		totalCPU       float64
+		totalDiskUsed  float64
+		totalDiskTotal float64
+		totalIndexing  int64
+		totalSearch    int64
+		count          int
+	)
+
+	for _, raw := range nodes {
+		n, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		count++
+
+		if jvm, ok := n["jvm"].(map[string]any); ok {
+			if mem, ok := jvm["mem"].(map[string]any); ok {
+				totalHeap += floatVal(mem["heap_used_percent"])
+			}
+		}
+
+		if osMap, ok := n["os"].(map[string]any); ok {
+			if cpu, ok := osMap["cpu"].(map[string]any); ok {
+				totalCPU += floatVal(cpu["percent"])
+			}
+		}
+
+		if fs, ok := n["fs"].(map[string]any); ok {
+			if total, ok := fs["total"].(map[string]any); ok {
+				tb := floatVal(total["total_in_bytes"])
+				ab := floatVal(total["available_in_bytes"])
+				totalDiskTotal += tb
+				totalDiskUsed += tb - ab
+			}
+		}
+
+		if indices, ok := n["indices"].(map[string]any); ok {
+			if indexing, ok := indices["indexing"].(map[string]any); ok {
+				totalIndexing += int64(floatVal(indexing["index_total"]))
+			}
+			if search, ok := indices["search"].(map[string]any); ok {
+				totalSearch += int64(floatVal(search["query_total"]))
+			}
+		}
+	}
+
+	if count > 0 {
+		m.JvmHeapUsedPercent = totalHeap / float64(count)
+		m.CPUPercent = totalCPU / float64(count)
+		if totalDiskTotal > 0 {
+			m.DiskUsedPercent = totalDiskUsed / totalDiskTotal * 100
+		}
+	}
+
+	// ── 3. Delta rates — zero on first cycle ──────────────────────────────
+	now := time.Now()
+	if c.lastIndexTotal != nil {
+		elapsed := now.Sub(c.lastTime).Seconds()
+		if elapsed > 0 {
+			m.IndexingRate = float64(totalIndexing-*c.lastIndexTotal) / elapsed
+			m.SearchRate = float64(totalSearch-*c.lastSearchTotal) / elapsed
+		}
+	}
+	c.lastIndexTotal = &totalIndexing
+	c.lastSearchTotal = &totalSearch
+	c.lastTime = now
+
+	// ── 4. Replication lag proxy ──────────────────────────────────────────
+	// OpenSearch has no WAL lag. A value of 0 means the cluster is green with
+	// no shards in motion — safe to consider fully in sync. 99 signals that
+	// shards are still relocating or the cluster is not yet green.
+	if m.ClusterStatus == 0 && m.RelocatingShards == 0 && m.InitializingShards == 0 {
+		m.ReplicationLagSeconds = 0
+	} else {
+		m.ReplicationLagSeconds = 99
+	}
+
+	return m, nil
+}
+
+func (c *collector) clusterHealth(baseURL, user, password string) (map[string]any, error) {
+	body, err := c.get(baseURL+"/_cluster/health", user, password)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse cluster health: %w", err)
+	}
+	return result, nil
+}
+
+func (c *collector) nodeStats(baseURL, user, password string) ([]any, error) {
+	body, err := c.get(baseURL+"/_nodes/stats/jvm,os,fs,indices", user, password)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse node stats: %w", err)
+	}
+	nodes, ok := result["nodes"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("missing nodes in response")
+	}
+	out := make([]any, 0, len(nodes))
+	for _, v := range nodes {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func (c *collector) get(url, user, password string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(user, password)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("opensearch http %d: %s", resp.StatusCode, snippet)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// encodeStatus converts the OpenSearch cluster status string to an integer so
+// that numeric alert rules can compare against it (0=green, 1=yellow, 2=red).
+func encodeStatus(s string) int {
+	switch s {
+	case "green":
+		return 0
+	case "yellow":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func floatVal(v any) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int64:
+		return float64(x)
+	case int:
+		return float64(x)
+	}
+	return 0
+}
+
+func intVal(v any) int {
+	return int(floatVal(v))
+}
+
+func stringVal(v any) string {
+	s, _ := v.(string)
+	return s
+}


### PR DESCRIPTION
Implements a new opensearchmetrics collector that scrapes cluster health and node stats from the OpenSearch REST API over HTTPS and reports them as opensearch.database metric sets to the platform.

Metrics collected:
- cluster_status (0=green, 1=yellow, 2=red — numeric for alert rules)
- active_shards, relocating_shards, initializing_shards, unassigned_shards
- active_primary_shards, number_of_nodes
- jvm_heap_used_percent, cpu_percent, disk_used_percent (averaged across nodes)
- indexing_rate, search_rate (per-second deltas from /_nodes/stats)
- replication_lag_seconds (0 when green+stable, 99 when shards in motion)

Uses InsecureSkipVerify for TLS — OpenSearch ships self-signed demo certs. Node stats are best-effort; cluster health alone is sufficient for basic alerting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/selfhost-dev/codesmith/hostlink/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786465071&installation_id=142051085&pr_number=217&repository=selfhost-dev%2Fhostlink&return_to=https%3A%2F%2Fgithub.com%2Fselfhost-dev%2Fhostlink%2Fpull%2F217&signature=a21c22ae06881922badf491dd5baca52f9e3e579f32d682e227c40551f8e6a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->